### PR TITLE
Adding separate route for refreshing a login token. 

### DIFF
--- a/test/rest.expired-token.test.js
+++ b/test/rest.expired-token.test.js
@@ -3,6 +3,7 @@ var request = require('request');
 var createApplication = require('./server-fixtures');
 
 describe('Test using an expired token', function() {
+  this.timeout(10000);
   var server;
   var app;
   var username = 'feathers';
@@ -58,9 +59,36 @@ describe('Test using an expired token', function() {
         assert.equal(body.name, 'TokenExpiredError', 'Got an error string back, not an object/array');
         done();
       });
-    }, 1900);
+    }, 2500);
   });
 
+  it('Requests to refresh an expired token will fail', function (done) {
+    setTimeout(function() {
+      request({
+        url: 'http://localhost:8888/api/login/refresh',
+        method: 'POST',
+        form: {
+          token: token
+        },
+        json: true
+      }, function (err, res, body) {
+        assert.equal(body.name, 'TokenExpiredError', 'Got an error string back, not an object/array');
+        done();
+      });
+    }, 2500);
+  });
 
+  it('Requests to refresh with no token will throw an error', function (done) {
+    request({
+      url: 'http://localhost:8888/api/login/refresh',
+      method: 'POST',
+      form: {
 
+      },
+      json: true
+    }, function (err, res) {
+      assert.equal(res.statusCode, 500, 'Throws error');
+      done();
+    });
+  });
 });

--- a/test/rest.test.js
+++ b/test/rest.test.js
@@ -3,7 +3,7 @@ var request = require('request');
 var createApplication = require('./server-fixtures');
 
 describe('REST API authentication', function() {
-  this.timeout(5000);
+  this.timeout(10000);
   var server;
   var app;
   var username = 'feathers';

--- a/test/rest.valid-token.test.js
+++ b/test/rest.valid-token.test.js
@@ -3,7 +3,7 @@ var request = require('request');
 var createApplication = require('./server-fixtures');
 
 describe('REST API authentication with valid auth token', function () {
-  this.timeout(5000);
+  this.timeout(10000);
   var server;
   var app;
   var username = 'feathers';
@@ -68,4 +68,20 @@ describe('REST API authentication with valid auth token', function () {
       done();
     });
   });
+
+  it('Requests to refresh a valid token will return data', function (done) {
+    request({
+      url: 'http://localhost:8888/api/login/refresh',
+      method: 'POST',
+      form: {
+        token: token
+      },
+      json: true
+    }, function (err, res, body) {
+      assert.ok(body.token, 'POST to /api/login gave us back a token.');
+      assert.equal(body.token, token, 'Token is the same');
+      done();
+    });
+  });
+
 });

--- a/test/socket-io.test.js
+++ b/test/socket-io.test.js
@@ -4,7 +4,7 @@ var io = require('socket.io-client');
 var createApplication = require('./server-fixtures');
 
 describe('Socket.io authentication', function() {
-  this.timeout(5000);
+  this.timeout(10000);
   var server;
   var app;
   var username = 'feathers';


### PR DESCRIPTION
Moved some of the token verification out to middleware as well. At the moment, the refresh is a POST to loginEndpoint + '/refresh'. We can always add the refresh URL as a configurable option.