### PR TITLE
Ten hours is only 36 seconds

### DIFF
--- a/src/middleware/index.js
+++ b/src/middleware/index.js
@@ -2,7 +2,7 @@ import Debug from 'debug';
 import errors from 'feathers-errors';
 
 const debug = Debug('feathers-authentication:middleware');
-const TEN_HOURS = 36000;
+const TEN_HOURS = 36000000;
 
 // Usually this is a big no no but passport requires the 
 // request object to inspect req.body and req.query so we


### PR DESCRIPTION
The cookies expiration date is currently set for 36 seconds in the future, not ten hours.