### PR TITLE
client should return a 401 error code when no token is provided

### DIFF
--- a/src/client/index.js
+++ b/src/client/index.js
@@ -1,5 +1,6 @@
 import * as hooks from './hooks';
 import { connected, authenticateSocket, getJWT, getStorage } from './utils';
+import errors from 'feathers-errors';
 
 const defaults = {
   tokenKey: 'feathers-jwt',
@@ -25,7 +26,7 @@ export default function(opts = {}) {
       if (!options.type) {
         getOptions = getJWT(config.tokenKey, this.get('storage')).then(token => {
           if (!token) {
-            return Promise.reject(new Error(`Could not find stored JWT and no authentication type was given`));
+            return Promise.reject(new errors.NotAuthenticated(`Could not find stored JWT and no authentication type was given`));
           }
 
           return { type: 'token', token };

--- a/test/client/index.test.js
+++ b/test/client/index.test.js
@@ -76,6 +76,7 @@ const setupTests = initApp => {
       .then(() => done(new Error('Should never get here')))
       .catch(error => {
         assert.equal(error.message, 'Could not find stored JWT and no authentication type was given');
+        assert.equal(error.code, 401);
         done();
       });
   });


### PR DESCRIPTION
If no token is provided to the `authenticate` call, a 401 code should be returned with the error.

This makes the [jQuery](https://github.com/feathersjs/feathers-docs/blame/master/guides/jquery.md#L196) and [React](https://github.com/feathersjs/feathers-docs/blame/master/guides/react.md#L246) guides redirect when a user lands on the chat.html without logging in.