### PR TITLE
[WIP] Add Google and Facebook authentication endpoints

### DIFF
--- a/src/client/index.js
+++ b/src/client/index.js
@@ -13,7 +13,9 @@ const defaults = {
   cookie: 'feathers-jwt',
   tokenKey: 'feathers-jwt',
   localEndpoint: '/auth/local',
-  tokenEndpoint: '/auth/token'
+  tokenEndpoint: '/auth/token',
+  facebookEndpoint: '/auth/facebook',
+  googleEndpoint: '/auth/google'
 };
 
 export default function(opts = {}) {
@@ -56,6 +58,10 @@ export default function(opts = {}) {
           endPoint = config.localEndpoint;
         } else if (options.type === 'token') {
           endPoint = config.tokenEndpoint;
+        } else if (options.type === 'facebook') {
+          endPoint = config.facebookEndpoint;
+        } else if (options.type === 'google') {
+          endPoint = config.googleEndpoint;
         } else {
           throw new Error(`Unsupported authentication 'type': ${options.type}`);
         }
@@ -80,7 +86,7 @@ export default function(opts = {}) {
       app.set('token', null);
 
       clearCookie(config.cookie);
-      
+
       // remove the token from localStorage
       return Promise.resolve(app.get('storage').setItem(config.tokenKey, '')).then(() => {
         // If using sockets de-authenticate the socket

--- a/src/index.js
+++ b/src/index.js
@@ -27,6 +27,8 @@ const defaults = {
   failureRedirect: '/auth/failure',
   tokenEndpoint: '/auth/token',
   localEndpoint: '/auth/local',
+  facebookEndpoint: '/auth/facebook',
+  googleEndpoint: '/auth/google',
   userEndpoint: '/users',
   header: 'authorization',
   cookie: {
@@ -58,7 +60,7 @@ export default function auth(config = {}) {
 
     // Merge and flatten options
     const authOptions = Object.assign({}, defaults, app.get('auth'), config);
-    
+
     // If a custom success redirect is passed in or it is disabled then we
     // won't setup the default route handler.
     if (authOptions.successRedirect !== defaults.successRedirect) {
@@ -83,7 +85,7 @@ export default function auth(config = {}) {
       // Get the token and expose it to REST services.
       app.use( middleware.normalizeAuthToken(authOptions) );
     }
-    
+
     app.use(passport.initialize());
 
     app.setup = function() {
@@ -106,7 +108,7 @@ export default function auth(config = {}) {
 
     // Merge all of our options and configure the appropriate service
     Object.keys(config).forEach(function (key) {
-      
+
       // Because we are iterating through all the keys we might
       // be dealing with a config param and not a provider config
       // If that's the case we don't need to merge params and we
@@ -124,7 +126,7 @@ export default function auth(config = {}) {
         // Check to see if it is an oauth2 provider
         if (providerOptions.clientID && providerOptions.clientSecret) {
           provider = oauth2;
-        } 
+        }
         // Check to see if it is an oauth1 provider
         else if (providerOptions.consumerKey && providerOptions.consumerSecret){
           throw new Error(`Sorry we don't support OAuth1 providers right now. Try using a ${key} OAuth2 provider.`);
@@ -132,9 +134,9 @@ export default function auth(config = {}) {
 
         providerOptions = Object.assign({ provider: key, endPoint: `/auth/${key}` }, providerOptions);
       }
-      
+
       const options = Object.assign({}, authOptions, providerOptions);
-      
+
       app.configure( provider(options) );
     });
 
@@ -145,7 +147,7 @@ export default function auth(config = {}) {
     // Setup route handler for default success redirect
     if (authOptions.shouldSetupSuccessRoute) {
       debug(`Setting up successRedirect route: ${authOptions.successRedirect}`);
-      
+
       app.get(authOptions.successRedirect, function(req, res){
         res.sendFile(path.resolve(__dirname, 'public', 'auth-success.html'));
       });


### PR DESCRIPTION
This is a PoC of enabling "stateless" client-side authentication for Google and Facebook. It simply exposes the `google` and `facebook` authentication types and maps it to the appropriate endpoints.

Use case for this manual and decoupled authentication workflow are primarily mobile applications (e.g. Cordova-based solutions like Ionic, etc.) and single-page applications in general. Additionally I personally like the resulting (more consistent) authentication API and a "Socket.io-only" solution (as there are no need for additional REST calls):
```js
feathers.authenticate({
  type: 'google',
  access_token: 'no42..aBcdef-gH42_...iJklM_4N_Op'
}).then(function (result) {
  console.log('Authenticated!', result)
  console.log(feathers.get('user'))
}).catch(function (error) {
  console.error(error)
})
```

## Edit: Google-Sidenote
To get google-token working I additionally had to fork `passport-google-token` (https://github.com/beevelop/passport-google-token). The current implementation fails quite silently if there is no refreshToken passed in the body (as it checks for the `req.query` and `req.headers` afterwards – what results in an unhandled error)