### PR TITLE
fix(oauth2): Use patch to update user in oauthCallback

### DIFF
--- a/src/services/oauth2/index.js
+++ b/src/services/oauth2/index.js
@@ -60,7 +60,7 @@ export class Service {
 
           debug(`Updating user: ${id}`);
 
-          return app.service(options.userEndpoint).update(id, data).then(updatedUser => {
+          return app.service(options.userEndpoint).patch(id, data).then(updatedUser => {
             return done(null, updatedUser);
           }).catch(done);
         }


### PR DESCRIPTION
Using update() leads to conflicts with non-default user models and effectively in loosing the user's
data. By using patch the data gets merged properly.

fixes #174