### PR TITLE
Use removeItem in the storage on logout

### DIFF
--- a/src/client/index.js
+++ b/src/client/index.js
@@ -80,9 +80,9 @@ export default function(opts = {}) {
       app.set('token', null);
 
       clearCookie(config.cookie);
-      
+
       // remove the token from localStorage
-      return Promise.resolve(app.get('storage').setItem(config.tokenKey, '')).then(() => {
+      return Promise.resolve(app.get('storage').removeItem(config.tokenKey)).then(() => {
         // If using sockets de-authenticate the socket
         if (app.io || app.primus) {
           const method = app.io ? 'emit' : 'send';

--- a/src/client/utils.js
+++ b/src/client/utils.js
@@ -66,7 +66,7 @@ export function getCookie(name) {
 // Returns the value for a cookie
 export function clearCookie(name) {
   if (typeof document !== 'undefined') {
-    document.cookie = `${name}=;expires=Thu, 01 Jan 1970 00:00:01 GMT;`; 
+    document.cookie = `${name}=;expires=Thu, 01 Jan 1970 00:00:01 GMT;`;
   }
 
   return null;
@@ -99,6 +99,11 @@ export function getStorage(storage) {
 
     setItem(key, value) {
       return (this.store[key] = value);
+    },
+
+    removeItem(key) {
+      delete this.store[key];
+      return this;
     }
   };
 }

--- a/test/client/index.test.js
+++ b/test/client/index.test.js
@@ -110,26 +110,30 @@ const setupTests = initApp => {
       }).catch(done);
   });
 
-  it('.logout works, does not grant access to protected service', done => {
+  it('.logout works, does not grant access to protected service and token is removed from localstorage', done => {
     app.authenticate({
-        type: 'local',
-        email, password
-      }).then(response => {
-        expect(response.token).to.not.equal(undefined);
-        expect(response.data).to.not.equal(undefined);
+      type: 'local',
+      email, password
+    }).then(response => {
+      expect(response.token).to.not.equal(undefined);
+      expect(response.data).to.not.equal(undefined);
 
-        app.logout().then(() => {
-          expect(app.get('token')).to.equal(null);
-          expect(app.get('user')).to.equal(null);
+      return app.logout().then(() => {
+        expect(app.get('token')).to.equal(null);
+        expect(app.get('user')).to.equal(null);
 
+
+        return Promise.resolve(app.get('storage').getItem('feathers-jwt')).then(token => {
+          expect(token).to.equal(undefined);
           app.service('messages').create({ text: 'auth test message' })
             .then(done)
             .catch(error => {
               expect(error.code).to.equal(401);
               done();
             });
-        }).catch(done);
-      }).catch(done);
+        });
+      });
+    }).catch(done);
   });
 };
 


### PR DESCRIPTION
`removeItem` is supported by both, LocalStorage and AsyncStorage so this PR adds it to the dummy storage and uses it when logging out (instead of setting it to an empty string).

Closes #203