### PR TITLE
jwt ssl warning

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -32,7 +32,7 @@ const defaults = {
   cookie: {
     name: 'feathers-jwt',
     httpOnly: false,
-    secure: process.env.NODE_ENV === 'production' ? true : false
+    secure: process.env.NODE_ENV === 'production'
   }
 };
 
@@ -56,9 +56,13 @@ export default function auth(config = {}) {
       config.local = {};
     }
 
+    if (config.cookie ){
+      config.cookie = Object.assign({}, defaults.cookie, config.cookie);
+    }
+
     // Merge and flatten options
-    const authOptions = Object.assign({}, defaults, app.get('auth'), config);
-    
+    const authOptions = Object.assign({}, defaults, app.get('auth'),config);
+
     // If a custom success redirect is passed in or it is disabled then we
     // won't setup the default route handler.
     if (authOptions.successRedirect !== defaults.successRedirect) {
@@ -83,7 +87,7 @@ export default function auth(config = {}) {
       // Get the token and expose it to REST services.
       app.use( middleware.normalizeAuthToken(authOptions) );
     }
-    
+
     app.use(passport.initialize());
 
     app.setup = function() {
@@ -106,7 +110,7 @@ export default function auth(config = {}) {
 
     // Merge all of our options and configure the appropriate service
     Object.keys(config).forEach(function (key) {
-      
+
       // Because we are iterating through all the keys we might
       // be dealing with a config param and not a provider config
       // If that's the case we don't need to merge params and we
@@ -124,7 +128,7 @@ export default function auth(config = {}) {
         // Check to see if it is an oauth2 provider
         if (providerOptions.clientID && providerOptions.clientSecret) {
           provider = oauth2;
-        } 
+        }
         // Check to see if it is an oauth1 provider
         else if (providerOptions.consumerKey && providerOptions.consumerSecret){
           throw new Error(`Sorry we don't support OAuth1 providers right now. Try using a ${key} OAuth2 provider.`);
@@ -132,9 +136,9 @@ export default function auth(config = {}) {
 
         providerOptions = Object.assign({ provider: key, endPoint: `/auth/${key}` }, providerOptions);
       }
-      
+
       const options = Object.assign({}, authOptions, providerOptions);
-      
+
       app.configure( provider(options) );
     });
 
@@ -145,7 +149,7 @@ export default function auth(config = {}) {
     // Setup route handler for default success redirect
     if (authOptions.shouldSetupSuccessRoute) {
       debug(`Setting up successRedirect route: ${authOptions.successRedirect}`);
-      
+
       app.get(authOptions.successRedirect, function(req, res){
         res.sendFile(path.resolve(__dirname, 'public', 'auth-success.html'));
       });

--- a/src/middleware/express.js
+++ b/src/middleware/express.js
@@ -81,26 +81,28 @@ export function successfulLogin(options = {}) {
       // clear any previous JWT cookie
       res.clearCookie(options.cookie.name);
 
-      // Only send back cookies when not in production or when in production and using HTTPS
-      if (!req.secure && process.env.NODE_ENV === 'production') {
-        console.error(`You should be using HTTPS in production! Refusing to send JWT in a cookie`);
+      // Check HTTPS and cookie status in production 
+      if (!req.secure && process.env.NODE_ENV === 'production' && options.cookie.secure) {
+        console.warn('WARN: Request isn\'t served through HTTPS: JWT in the cookie is exposed.');
+        console.info('If you are behind a proxy (e.g. NGINX) you can:');
+        console.info('- trust it: http://expressjs.com/en/guide/behind-proxies.html');
+        console.info('- set cookie.secure false');
       }
-      else {
-        const cookieOptions = Object.assign({}, options.cookie, { path: options.successRedirect });
 
-        // If a custom expiry wasn't passed then set the expiration to be 30 seconds from now.
-        if (cookieOptions.expires === undefined) {
-          const expiry = new Date();
-          expiry.setTime(expiry.getTime() + THIRTY_SECONDS);
-          cookieOptions.expires = expiry;
-        }
+      const cookieOptions = Object.assign({}, options.cookie, { path: options.successRedirect });
 
-        if ( !(cookieOptions.expires instanceof Date) ) {
-          throw new Error('cookie.expires must be a valid Date object');
-        }
-
-        res.cookie(options.cookie.name, res.data.token, cookieOptions);
+      // If a custom expiry wasn't passed then set the expiration to be 30 seconds from now.
+      if (cookieOptions.expires === undefined) {
+        const expiry = new Date();
+        expiry.setTime(expiry.getTime() + THIRTY_SECONDS);
+        cookieOptions.expires = expiry;
       }
+
+      if ( !(cookieOptions.expires instanceof Date) ) {
+        throw new Error('cookie.expires must be a valid Date object');
+      }
+
+      res.cookie(options.cookie.name, res.data.token, cookieOptions);
     }
 
     // Redirect to our success route

--- a/test/src/index.test.js
+++ b/test/src/index.test.js
@@ -281,6 +281,18 @@ describe('Feathers Authentication', () => {
           expect(app.get('auth').cookie.expires).to.equal(expiration);
         });
 
+        it('allows overriding cookie partially', () => {
+          app.configure(authentication({
+            cookie: {
+              secure: false
+            }
+          }));
+          expect(typeof app.get('auth').cookie).to.equal('object');
+          expect(app.get('auth').cookie.name).to.equal('feathers-jwt');
+          expect(app.get('auth').cookie.secure).to.equal(false);
+          expect(app.get('auth').cookie.httpOnly).to.equal(false);
+        });
+
         it('allows overriding token', () => {
           app.configure(authentication({
             token: {

--- a/test/src/middleware.test.js
+++ b/test/src/middleware.test.js
@@ -231,18 +231,24 @@ describe('Middleware', () => {
           expect(MockResponse.clearCookie).to.have.been.calledWith('feathers-jwt');
         });
 
-        it('throws an error if not using HTTPS in production', () => {
-          MockRequest.secure = false;
+        it('throws a warning if not using HTTPS in production', () => {
+          let MockConsoleWarn = sinon.stub(console, 'warn');
           process.env.NODE_ENV = 'production';
+          MockRequest.secure = false;
+          options.cookie = { 
+            name: 'feathers-jwt',
+            secure:true
+          };
+          
+          MockResponse.data.token = 'token';
 
-          try {
-            middleware.successfulLogin(options)(MockRequest, MockResponse, MockNext);  
-          }
-          catch(error) {
-            expect(error).to.not.equal(undefined);
-          }
-
+          middleware.successfulLogin(options)(MockRequest, MockResponse, MockNext);
+          expect(MockResponse.cookie).to.have.been.calledWith('feathers-jwt', 'token');
+          expect(console.warn).to.have.been
+            .calledWith('WARN: Request isn\'t served through HTTPS: JWT in the cookie is exposed.');
+          
           process.env.NODE_ENV = undefined;
+          MockConsoleWarn.reset();
         });
 
         it('throws an error if expires is not a date', () => {


### PR DESCRIPTION
- Fire a warning if the request is insecure rather than refusing to send the cookie. 
- Allow override a single cookie property 

Please have a look https://github.com/feathersjs/feathers-authentication/compare/master...aboutlo:ls-JWT-ssl-warning?diff=unified&expand=1&name=ls-JWT-ssl-warning#diff-1fdf421c05c1140f6d71444ea2b27638L60

In my opinion `app.get('auth')` is always undefined at this stage. 