### PR TITLE
Lowercase custom header

### DIFF
--- a/src/client/hooks.js
+++ b/src/client/hooks.js
@@ -13,7 +13,7 @@ export function populateHeader(options = {}) {
   return function(hook) {
     if (hook.params.token) {
       hook.params.headers = Object.assign({}, {
-        [options.header || 'Authorization']: hook.params.token
+        [options.header || 'authorization']: hook.params.token
       }, hook.params.headers);
     }
   };

--- a/src/middleware/express.js
+++ b/src/middleware/express.js
@@ -32,7 +32,8 @@ export function normalizeAuthToken(options = {}) {
   }
 
   return function(req, res, next) {
-    let token = req.headers[options.header];
+    // Normalize header capitalization the same way Node.js does
+    let token = req.headers[options.header.toLowerCase()];
 
     // Check the header for the token (preferred method)
     if (token) {

--- a/test/integration/rest.test.js
+++ b/test/integration/rest.test.js
@@ -12,6 +12,7 @@ describe('REST authentication', function() {
   let password = 'test';
   let settings = {
     idField: 'id',
+    header: 'X-Auth',
     token: {
       secret: 'feathers-rocks'
     }
@@ -259,7 +260,7 @@ describe('REST authentication', function() {
             method: 'GET',
             json: true,
             headers: {
-              Authorization: validToken
+              'X-Auth': validToken
             }
           };
         });


### PR DESCRIPTION
#### Background

This ensures that if a custom server-side `header` value is set authentication still works. Currently on master requests fail if a custom `header` value is set to a string with capital letters. See the linked issue for additional background. If this patch is accepted I'll update the docs.

Fixes #218.

#### Test steps

1. Add an example `header` key with `"Example-Header"` to the example app.

1. Create a new token by making a `POST` request to `/auth/local` with the default user credentials.

1. Use that token with to make a request to `/messages`.

  - [ ] Verify that you are able to authenticate with a capitalized header (`Example-Header`).
  - [ ] Verify that you are able to authenticate with a lowercase header (`example-header`).