### PR TITLE
added support for hashing passwords when hook.data is an array

### DIFF
--- a/src/hooks/hash-password.js
+++ b/src/hooks/hash-password.js
@@ -4,8 +4,8 @@ import bcrypt from 'bcryptjs';
 
 const defaults = { passwordField: 'password' };
 
-export default function(options = {}){
-  return function(hook) {
+export default function (options = {}) {
+  return function (hook) {
     if (hook.type !== 'before') {
       throw new Error(`The 'hashPassword' hook should only be used as a 'before' hook.`);
     }
@@ -18,7 +18,20 @@ export default function(options = {}){
       return hook;
     }
 
-    const password = hook.data[options.passwordField];
+    let password;
+    if (Array.isArray(hook.data)) {
+      // make sure we actually have password fields
+      const dataToCheck = [].concat(hook.data);
+      dataToCheck.filter(item => {
+        return item.hasOwnProperty(options.passwordField);
+      });
+      if (dataToCheck.length > 0) {
+        // set it to the array so we can iterate later on it
+        password = hook.data;
+      }
+    } else {
+      password = hook.data[options.passwordField];
+    }
 
     if (password === undefined) {
       if (!hook.params.provider) {
@@ -28,16 +41,27 @@ export default function(options = {}){
       throw new errors.BadRequest(`'${options.passwordField}' field is missing.`);
     }
 
-    return new Promise(function(resolve, reject){
-      crypto.genSalt(10, function(error, salt) {
-        crypto.hash(password, salt, function(error, hash) {
+    return new Promise(function (resolve, reject) {
+      const hash = function(item, password, salt) {
+        crypto.hash(password, salt, function (error, hash) {
           if (error) {
             return reject(error);
           }
-
-          hook.data[options.passwordField] = hash;
+          item[options.passwordField] = hash;
           resolve(hook);
         });
+      };
+      crypto.genSalt(10, function (error, salt) {
+        if (Array.isArray(password)) {
+          password.map((item) => {
+            if (!item.hasOwnProperty(options.passwordField)) {
+              return false;
+            }
+            hash(item, item[options.passwordField], salt);
+          });
+        } else {
+          hash(hook.data, password, salt);
+        }
       });
     });
   };

--- a/test/src/hooks/hash-password.test.js
+++ b/test/src/hooks/hash-password.test.js
@@ -120,4 +120,55 @@ describe('hashPassword', () => {
       });
     });
   });
+
+  describe('when password exists in bulk', () => {
+    let hook;
+
+    beforeEach(() => {
+      hook = {
+        type: 'before',
+        data: [{password: 'secret'}, {password: 'secret'}],
+        app: {
+          get: function() { return {}; }
+        }
+      };
+    });
+
+    it('hashes with default options', (done) => {
+      hashPassword()(hook).then(hook => {
+        hook.data.map(item => {
+          expect(item.password).to.not.equal(undefined);
+          expect(item.password).to.not.equal('secret');
+        });
+        done();
+      });
+    });
+
+    it('hashes with options from global auth config', (done) => {
+      hook.data = [{pass: 'secret'}, {pass: 'secret'}];
+      hook.app.get = function() {
+        return { passwordField: 'pass' };
+      };
+
+      hashPassword()(hook).then(hook => {
+        hook.data.map(item => {
+          expect(item.pass).to.not.equal(undefined);
+          expect(item.pass).to.not.equal('secret');
+        });
+        done();
+      });
+    });
+
+    it('hashes with custom options', (done) => {
+      hook.data = [{pass: 'secret'}, {pass: 'secret'}];
+
+      hashPassword({ passwordField: 'pass'})(hook).then(hook => {
+        hook.data.map(item => {
+          expect(item.pass).to.not.equal(undefined);
+          expect(item.pass).to.not.equal('secret');
+        });
+        done();
+      });
+    });
+  });
 });


### PR DESCRIPTION
feathers-sequelize allows you to bulk create (maybe other adapters do too?), in my case I was bulk creating predefined set of users (like admins, etc) and I noticed the auth was failing and later discovered the passwords were not being hashed at all.

We could always loop thru the array and call `.create()` individually, but *I think* this should be supported by the `hashPassword` hook, I certainly thought it was!