### PR TITLE
Adds ability to limit queries unless authenticated and authorized

### DIFF
--- a/example/app.js
+++ b/example/app.js
@@ -45,10 +45,19 @@ approvedMessageService.create({text: 'A million people walk into a Silicon Valle
 approvedMessageService.create({text: 'Nobody buys anything', approved: true}, {}, function(){});
 approvedMessageService.create({text: 'Bar declared massive success', approved: true}, {}, function(){});
 
+
 // Will merge this restriction with the query params
 var restriction = { restrict: {approved: true} };
 
 approvedMessageService.before({
+  all: [
+    // Necessary since restrict must always use find and hook id is a string when the memory service expects it as a number
+    function(hook) {
+      if(hook.id) {
+        hook.id = parseInt(hook.id, 10);
+      }
+    }
+  ],
   find: [
     authentication.hooks.verifyOrRestrict(restriction),
     authentication.hooks.populateOrRestrict(restriction),

--- a/example/app.js
+++ b/example/app.js
@@ -23,6 +23,7 @@ var app = feathers()
   .use('/users', memory())
   // A simple Message service that we can used for testing
   .use('/messages', memory())
+  .use('/approved-messages', memory())
   .use('/', feathers.static(__dirname + '/public'))
   .use(errorHandler());
 
@@ -39,9 +40,31 @@ messageService.before({
   ]
 })
 
+var approvedMessageService = app.service('/approved-messages');
+approvedMessageService.create({text: 'A million people walk into a Silicon Valley bar', approved: false}, {}, function(){});
+approvedMessageService.create({text: 'Nobody buys anything', approved: true}, {}, function(){});
+approvedMessageService.create({text: 'Bar declared massive success', approved: true}, {}, function(){});
+
+// Will merge this restriction with the query params
+var restriction = { restrict: {approved: true} };
+
+approvedMessageService.before({
+  find: [
+    authentication.hooks.verifyOrRestrict(restriction),
+    authentication.hooks.populateOrRestrict(restriction),
+    authentication.hooks.hasRoleOrRestrict(Object.assign({roles: ['admin']}, restriction))
+  ],
+  get: [
+    authentication.hooks.verifyOrRestrict(restriction),
+    authentication.hooks.populateOrRestrict(restriction),
+    authentication.hooks.hasRoleOrRestrict(Object.assign({roles: ['admin']}, restriction))
+  ]
+})
+
+
 var userService = app.service('users');
 
-// Add a hook to the user service that automatically replaces 
+// Add a hook to the user service that automatically replaces
 // the password with a hash of the password before saving it.
 userService.before({
   create: authentication.hooks.hashPassword()
@@ -50,7 +73,8 @@ userService.before({
 // Create a user that we can use to log in
 var User = {
   email: 'admin@feathersjs.com',
-  password: 'admin'
+  password: 'admin',
+  roles: ['admin']
 };
 
 userService.create(User, {}).then(function(user) {

--- a/example/client.js
+++ b/example/client.js
@@ -19,9 +19,15 @@ app.authenticate({
   'password': 'admin'
 }).then(function(result){
   console.log(`Successfully authenticated against ${host}!`, result);
-  
+
   app.service('messages').find({}).then(function(data){
     console.log('messages', data);
+  }).catch(function(error){
+    console.error('Error finding data', error);
+  });
+
+  app.service('approved-messages').find({}).then(function(data){
+    console.log('approvedMessages', data);
   }).catch(function(error){
     console.error('Error finding data', error);
   });

--- a/example/public/index.html
+++ b/example/public/index.html
@@ -161,9 +161,15 @@
           console.log('Authenticated!', result);
 
           alert('You successfully authenticated over sockets with email and password. Your new JWT is:\n\n' + app.get('token'));
-          
+
           app.service('messages').find({}).then(function(data){
             console.log('messages', data);
+          }).catch(function(error){
+            console.error('Error finding data', error);
+          });
+
+          app.service('approvedMessages').find({}).then(function(data){
+            console.log('approvedMessages', data);
           }).catch(function(error){
             console.error('Error finding data', error);
           });

--- a/src/hooks/has-role-or-restrict.js
+++ b/src/hooks/has-role-or-restrict.js
@@ -30,12 +30,12 @@ export default function(options = {}){
     options = Object.assign({}, defaults, hook.app.get('auth'), options);
 
     // If we don't have a user we have to always use find instead of get because we must not return id queries that are unrestricted and we don't want the developer to have to add after hooks.
-    var query = Object.assign({}, hook.params.query, options.restrict);
+    let query = Object.assign({}, hook.params.query, options.restrict);
 
     if(hook.id !== null && hook.id !== undefined) {
       const id = {};
       id[options.idField] = hook.id;
-      var query = Object.assign(query, id);
+      query = Object.assign(query, id);
     }
 
     // Set provider as undefined so we avoid an infinite loop if this hook is
@@ -57,8 +57,7 @@ export default function(options = {}){
           return hook;
         }
         throw new errors.NotFound(`No record found`);
-      }).catch(err => {
-        console.log("err", err);
+      }).catch(() => {
         throw new errors.NotFound(`No record found`);
       });
     }
@@ -139,8 +138,7 @@ export default function(options = {}){
           return hook;
         }
         throw new errors.NotFound(`No record found`);
-      }).catch(err => {
-        console.log("err", err);
+      }).catch(() => {
         throw new errors.NotFound(`No record found`);
       });
     }

--- a/src/hooks/has-role-or-restrict.js
+++ b/src/hooks/has-role-or-restrict.js
@@ -1,0 +1,148 @@
+import errors from 'feathers-errors';
+import isPlainObject from 'lodash.isplainobject';
+
+const defaults = {
+  fieldName: 'roles',
+  idField: '_id',
+  ownerField: 'userId',
+  owner: false
+};
+
+export default function(options = {}){
+  if (!options.roles || !options.roles.length) {
+    throw new Error(`You need to provide an array of 'roles' to check against.`);
+  }
+
+  return function(hook) {
+    if (hook.type !== 'before') {
+      throw new Error(`The 'hasRoleOrRestrict' hook should only be used as a 'before' hook.`);
+    }
+
+    // If it was an internal call then skip this hook
+    if (!hook.params.provider) {
+      return hook;
+    }
+
+    if(hook.result) {
+      return hook;
+    }
+
+    options = Object.assign({}, defaults, hook.app.get('auth'), options);
+
+    // If we don't have a user we have to always use find instead of get because we must not return id queries that are unrestricted and we don't want the developer to have to add after hooks.
+    var query = Object.assign({}, hook.params.query, options.restrict);
+
+    if(hook.id !== null && hook.id !== undefined) {
+      const id = {};
+      id[options.idField] = hook.id;
+      var query = Object.assign(query, id);
+    }
+
+    // Set provider as undefined so we avoid an infinite loop if this hook is
+    // set on the resource we are requesting.
+    const params = Object.assign({}, hook.params, { provider: undefined });
+
+    if (!hook.params.user) {
+      if(hook.result) {
+        return hook;
+      }
+
+      return this.find({ query }, params).then(results => {
+        if(results.length >= 1) {
+          if(hook.id !== undefined && hook.id !== null) {
+            hook.result = results[0];
+          } else {
+            hook.result = results;
+          }
+          return hook;
+        }
+        throw new errors.NotFound(`No record found`);
+      }).catch(err => {
+        console.log("err", err);
+        throw new errors.NotFound(`No record found`);
+      });
+    }
+
+    let authorized = false;
+    let roles = hook.params.user[options.fieldName];
+    const id = hook.params.user[options.idField];
+    const error = new errors.Forbidden('You do not have valid permissions to access this.');
+
+    if (id === undefined) {
+      throw new Error(`'${options.idField} is missing from current user.'`);
+    }
+
+    // If the user doesn't even have a `fieldName` field and we're not checking
+    // to see if they own the requested resource return Forbidden error
+    if (!options.owner && roles === undefined) {
+      throw error;
+    }
+
+    // If the roles is not an array, normalize it
+    if (!Array.isArray(roles)) {
+      roles = [roles];
+    }
+
+    // Iterate through all the roles the user may have and check
+    // to see if any one of them is in the list of permitted roles.
+    authorized = roles.some(role => options.roles.indexOf(role) !== -1);
+
+    // If we should allow users that own the resource and they don't already have
+    // the permitted roles check to see if they are the owner of the requested resource
+    if (options.owner && !authorized) {
+      if (!hook.id) {
+        throw new errors.MethodNotAllowed(`The 'hasRoleOrRestrict' hook should only be used on the 'get', 'update', 'patch' and 'remove' service methods if you are using the 'owner' field.`);
+      }
+
+      // look up the document and throw a Forbidden error if the user is not an owner
+      return new Promise((resolve, reject) => {
+        // Set provider as undefined so we avoid an infinite loop if this hook is
+        // set on the resource we are requesting.
+        const params = Object.assign({}, hook.params, { provider: undefined });
+
+        this.get(hook.id, params).then(data => {
+          if (data.toJSON) {
+            data = data.toJSON();
+          }
+          else if (data.toObject) {
+            data = data.toObject();
+          }
+
+          let field = data[options.ownerField];
+
+          // Handle nested Sequelize or Mongoose models
+          if (isPlainObject(field)) {
+            field = field[options.idField];
+          }
+
+          if ( field === undefined || field.toString() !== id.toString() ) {
+            reject(new errors.Forbidden('You do not have the permissions to access this.'));
+          }
+
+          resolve(hook);
+        }).catch(reject);
+      });
+    }
+
+    if (!authorized) {
+      if(hook.result) {
+        return hook;
+      }
+
+      return this.find({ query }, params).then(results => {
+        if(results.length >= 1) {
+          if(hook.id !== undefined && hook.id !== null) {
+            hook.result = results[0];
+          } else {
+            hook.result = results;
+          }
+          return hook;
+        }
+        throw new errors.NotFound(`No record found`);
+      }).catch(err => {
+        console.log("err", err);
+        throw new errors.NotFound(`No record found`);
+      });
+    }
+  };
+}

--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -6,6 +6,9 @@ import restrictToAuthenticated from './restrict-to-authenticated';
 import restrictToOwner from './restrict-to-owner';
 import restrictToRoles from './restrict-to-roles';
 import verifyToken from './verify-token';
+import verifyOrRestrict from './verify-or-restrict';
+import populateOrRestrict from './populate-or-restrict';
+import hasRoleOrRestrict from './has-role-or-restrict';
 
 let hooks = {
   associateCurrentUser,
@@ -15,7 +18,10 @@ let hooks = {
   restrictToAuthenticated,
   restrictToOwner,
   restrictToRoles,
-  verifyToken
+  verifyToken,
+  verifyOrRestrict,
+  populateOrRestrict,
+  hasRoleOrRestrict
 };
 
 export default hooks;

--- a/src/hooks/populate-or-restrict.js
+++ b/src/hooks/populate-or-restrict.js
@@ -1,3 +1,5 @@
+import errors from 'feathers-errors';
+
 /**
  * Populate the current user associated with the JWT
  */
@@ -23,7 +25,7 @@ export default function(options = {}){
     }
 
     // If we don't have a payload we have to always use find instead of get because we must not return id queries that are unrestricted and we don't want the developer to have to add after hooks.
-    var query = Object.assign({}, hook.params.query, options.restrict);
+    let query = Object.assign({}, hook.params.query, options.restrict);
 
     // Set provider as undefined so we avoid an infinite loop if this hook is
     // set on the resource we are requesting.
@@ -32,7 +34,7 @@ export default function(options = {}){
     if(hook.id !== null && hook.id !== undefined) {
       const id = {};
       id[options.idField] = hook.id;
-      var query = Object.assign(query, id);
+      query = Object.assign(query, id);
     }
 
     // Check to see if we have an id from a decoded JWT
@@ -53,8 +55,7 @@ export default function(options = {}){
           return hook;
         }
         throw new errors.NotFound(`No record found`);
-      }).catch(err => {
-        console.log("err", err);
+      }).catch(() => {
         throw new errors.NotFound(`No record found`);
       });
     }
@@ -64,7 +65,7 @@ export default function(options = {}){
       return Promise.resolve(hook);
     }
 
-    return new Promise(function(resolve, reject){
+    return new Promise(function(resolve){
       hook.app.service(options.userEndpoint).get(id, {}).then(user => {
         // attach the user to the hook for use in other hooks or services
         hook.params.user = user;
@@ -78,7 +79,7 @@ export default function(options = {}){
         }
 
         return resolve(hook);
-      }).catch(err => {
+      }).catch(() => {
 
         if(hook.result) {
           return hook;
@@ -95,7 +96,7 @@ export default function(options = {}){
           }
 
           throw new errors.NotFound(`No record found`);
-        }).catch(err => {
+        }).catch(() => {
           throw new errors.NotFound(`No record found`);
         });
       });

--- a/src/hooks/populate-or-restrict.js
+++ b/src/hooks/populate-or-restrict.js
@@ -1,0 +1,104 @@
+/**
+ * Populate the current user associated with the JWT
+ */
+const defaults = {
+  userEndpoint: '/users',
+  idField: '_id'
+};
+
+export default function(options = {}){
+  return function(hook) {
+    let id;
+
+    options = Object.assign({}, defaults, hook.app.get('auth'), options);
+
+    // If it's an after hook grab the id from the result
+    if (hook.type !== 'before') {
+      throw new Error(`The 'populateOrRestrict' hook should only be used as a 'before' hook.`);
+    }
+
+    // If it was an internal call then skip this hook
+    if (!hook.params.provider) {
+      return hook;
+    }
+
+    // If we don't have a payload we have to always use find instead of get because we must not return id queries that are unrestricted and we don't want the developer to have to add after hooks.
+    var query = Object.assign({}, hook.params.query, options.restrict);
+
+    // Set provider as undefined so we avoid an infinite loop if this hook is
+    // set on the resource we are requesting.
+    const params = Object.assign({}, hook.params, { provider: undefined });
+
+    if(hook.id !== null && hook.id !== undefined) {
+      const id = {};
+      id[options.idField] = hook.id;
+      var query = Object.assign(query, id);
+    }
+
+    // Check to see if we have an id from a decoded JWT
+    if (hook.params.payload) {
+      id = hook.params.payload[options.idField];
+    } else {
+      if(hook.result) {
+        return hook;
+      }
+
+      return this.find({ query }, params).then(results => {
+        if(results.length >= 1) {
+          if(hook.id !== undefined && hook.id !== null) {
+            hook.result = results[0];
+          } else {
+            hook.result = results;
+          }
+          return hook;
+        }
+        throw new errors.NotFound(`No record found`);
+      }).catch(err => {
+        console.log("err", err);
+        throw new errors.NotFound(`No record found`);
+      });
+    }
+
+    // If we didn't find an id then just pass through
+    if (id === undefined) {
+      return Promise.resolve(hook);
+    }
+
+    return new Promise(function(resolve, reject){
+      hook.app.service(options.userEndpoint).get(id, {}).then(user => {
+        // attach the user to the hook for use in other hooks or services
+        hook.params.user = user;
+
+        // If it's an after hook attach the user to the response
+        if (hook.result) {
+          hook.result.data = Object.assign({}, user = !user.toJSON ? user : user.toJSON());
+
+          // remove the id field from the root, it already exists inside the user object
+          delete hook.result[options.idField];
+        }
+
+        return resolve(hook);
+      }).catch(err => {
+
+        if(hook.result) {
+          return hook;
+        }
+
+        return this.find({ query }, params).then(results => {
+          if(results.length >= 1) {
+            if(hook.id !== undefined && hook.id !== null) {
+              hook.result = results[0];
+            } else {
+              hook.result = results;
+            }
+            return hook;
+          }
+
+          throw new errors.NotFound(`No record found`);
+        }).catch(err => {
+          throw new errors.NotFound(`No record found`);
+        });
+      });
+    });
+  };
+}

--- a/src/hooks/verify-or-restrict.js
+++ b/src/hooks/verify-or-restrict.js
@@ -1,0 +1,83 @@
+import jwt from 'jsonwebtoken';
+import errors from 'feathers-errors';
+
+export default function(options = {}){
+  return function(hook) {
+
+    if (hook.type !== 'before') {
+      throw new Error(`The 'verifyOrRestrict' hook should only be used as a 'before' hook.`);
+    }
+
+    // If it was an internal call then skip this hook
+    if (!hook.params.provider) {
+      return hook;
+    }
+
+    const token = hook.params.token;
+
+    const authOptions = hook.app.get('auth') || {};
+
+    // Grab the token options here
+    options = Object.assign({}, authOptions, authOptions.token, options);
+
+    if (!token) {
+
+      // We have to always use find instead of get because we must not return id queries that are unrestricted and we don't want the developer to have to add after hooks.
+      var query = Object.assign({}, hook.params.query, options.restrict);
+
+      // Set provider as undefined so we avoid an infinite loop if this hook is
+      // set on the resource we are requesting.
+      const params = Object.assign({}, hook.params, { provider: undefined });
+
+      if(hook.id !== null && hook.id !== undefined) {
+        const id = {};
+        id[options.idField] = hook.id;
+        var query = Object.assign(query, id);
+      }
+
+      return this.find({ query }, params).then(results => {
+        if(results.length >= 1) {
+          if(hook.id !== undefined && hook.id !== null) {
+            hook.result = results[0];
+          } else {
+            hook.result = results;
+          }
+          return hook;
+        }
+
+        throw new errors.NotFound(`No record found`);
+      }).catch(err => {
+        console.log("err", err);
+        throw new errors.NotFound(`No record found`);
+      });
+
+    } else {
+
+      const secret = options.secret;
+
+      if (!secret) {
+        throw new Error(`You need to pass 'options.secret' to the verifyToken() hook or set 'auth.token.secret' it in your config.`);
+      }
+
+      // Convert the algorithm value to an array
+      if (options.algorithm) {
+        options.algorithms = [options.algorithm];
+        delete options.algorithm;
+      }
+
+      return new Promise(function(resolve, reject){
+        jwt.verify(token, secret, options, function (error, payload) {
+          if (error) {
+            // If the user is trying to add a token then it is better to throw and error than let the request go through with a restriction
+            return reject(new errors.NotAuthenticated(error));
+          }
+
+          // Attach our decoded token payload to the params
+          hook.params.payload = payload;
+
+          resolve(hook);
+        });
+      });
+    }
+  };
+}

--- a/src/hooks/verify-or-restrict.js
+++ b/src/hooks/verify-or-restrict.js
@@ -23,7 +23,7 @@ export default function(options = {}){
     if (!token) {
 
       // We have to always use find instead of get because we must not return id queries that are unrestricted and we don't want the developer to have to add after hooks.
-      var query = Object.assign({}, hook.params.query, options.restrict);
+      let query = Object.assign({}, hook.params.query, options.restrict);
 
       // Set provider as undefined so we avoid an infinite loop if this hook is
       // set on the resource we are requesting.
@@ -32,7 +32,7 @@ export default function(options = {}){
       if(hook.id !== null && hook.id !== undefined) {
         const id = {};
         id[options.idField] = hook.id;
-        var query = Object.assign(query, id);
+        query = Object.assign(query, id);
       }
 
       return this.find({ query }, params).then(results => {
@@ -46,8 +46,7 @@ export default function(options = {}){
         }
 
         throw new errors.NotFound(`No record found`);
-      }).catch(err => {
-        console.log("err", err);
+      }).catch(() => {
         throw new errors.NotFound(`No record found`);
       });
 

--- a/src/hooks/verify-token.js
+++ b/src/hooks/verify-token.js
@@ -19,7 +19,7 @@ export default function(options = {}){
     }
 
     const authOptions = hook.app.get('auth') || {};
-    
+
     // Grab the token options here
     options = Object.assign({}, authOptions.token, options);
 
@@ -41,7 +41,7 @@ export default function(options = {}){
           // Return a 401 if the token has expired or is invalid.
           return reject(new errors.NotAuthenticated(error));
         }
-        
+
         // Attach our decoded token payload to the params
         hook.params.payload = payload;
 

--- a/test/src/hooks/has-role-or-restrict.test.js
+++ b/test/src/hooks/has-role-or-restrict.test.js
@@ -73,7 +73,6 @@ describe('hasRoleOrRestrict', () => {
         expect(returnedHook).to.deep.equal(hook);
       }
       catch(error) {
-        console.log("error", error);
         // It should never get here
         expect(true).to.equal(false);
       }
@@ -90,12 +89,12 @@ describe('hasRoleOrRestrict', () => {
         type: 'before',
         params: {
           provider: 'rest',
-          query: {author: "James"}
+          query: {author: 'James'}
         }
       };
 
       hook = hasRoleOrRestrict({ roles: ['admin'], restrict: {approved: true} }).call(mockService, hook);
-      expect(mockFind).to.be.calledWith({ query: {author: "James", approved: true} }, { provider: undefined, query: { author: "James" } });
+      expect(mockFind).to.be.calledWith({ query: {author: 'James', approved: true} }, { provider: undefined, query: { author: 'James' } });
     });
 
     it('if hook.id is set, merge the restriction and the id into the query and call find', () => {
@@ -112,7 +111,7 @@ describe('hasRoleOrRestrict', () => {
       };
 
       hook = hasRoleOrRestrict({ roles: ['admin'], restrict: {approved: true}, idField: '_id'}).call(mockService, hook);
-      expect(mockFind).to.be.calledWith({ query:{'_id': "525235", approved: true} }, { provider: undefined });
+      expect(mockFind).to.be.calledWith({ query:{'_id': '525235', approved: true} }, { provider: undefined });
     });
   });
 
@@ -179,12 +178,12 @@ describe('hasRoleOrRestrict', () => {
           type: 'before',
           params: {
             provider: 'rest',
-            query: {author: "James"}
+            query: {author: 'James'}
           }
         };
 
         hook = hasRoleOrRestrict({ roles: ['admin'], restrict: {approved: true} }).call(mockService, hook);
-        expect(mockFind).to.be.calledWith({ query: {author: "James", approved: true} }, { provider: undefined, query: { author: "James" } });
+        expect(mockFind).to.be.calledWith({ query: {author: 'James', approved: true} }, { provider: undefined, query: { author: 'James' } });
       });
 
       it('if hook.id is set, merge the restriction and the id into the query and call find', () => {
@@ -201,7 +200,7 @@ describe('hasRoleOrRestrict', () => {
         };
 
         hook = hasRoleOrRestrict({ roles: ['admin'], restrict: {approved: true}, idField: '_id'}).call(mockService, hook);
-        expect(mockFind).to.be.calledWith({ query:{'_id': "525235", approved: true} }, { provider: undefined });
+        expect(mockFind).to.be.calledWith({ query:{'_id': '525235', approved: true} }, { provider: undefined });
       });
 
       describe('when owner option enabled', () => {

--- a/test/src/hooks/has-role-or-restrict.test.js
+++ b/test/src/hooks/has-role-or-restrict.test.js
@@ -1,0 +1,339 @@
+import chai, { expect } from 'chai';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+chai.use(sinonChai);
+
+import { hasRoleOrRestrict } from '../../../src/hooks';
+
+let mockFind = sinon.stub().returns(Promise.resolve([{text: 'test', approved: true}]));
+let mockService = {
+  find: mockFind
+};
+
+let MockData;
+let MockService;
+let options;
+
+describe('hasRoleOrRestrict', () => {
+  beforeEach(() => {
+    MockData = {
+      userId: '1',
+      text: 'hey'
+    };
+    MockService = {
+      get: sinon.stub().returns(Promise.resolve(MockData)),
+      find: mockFind
+    };
+    options = { roles: ['admin', 'super'], restrict: {approved: true} };
+  });
+
+  it('throws an error when roles are missing', () => {
+    try {
+      hasRoleOrRestrict();
+    }
+    catch(error) {
+      expect(error).to.not.equal(undefined);
+    }
+  });
+
+  it('throws an error when roles are empty', () => {
+    try {
+      hasRoleOrRestrict({ roles: [] });
+    }
+    catch(error) {
+      expect(error).to.not.equal(undefined);
+    }
+  });
+
+  describe('when not called as a before hook', () => {
+    it('throws an error', () => {
+      let hook = {
+        type: 'after'
+      };
+
+      try {
+        hasRoleOrRestrict(options)(hook);
+      }
+      catch(error) {
+        expect(error).to.not.equal(undefined);
+      }
+    });
+  });
+
+  describe('when provider does not exist', () => {
+    it('does not do anything', () => {
+      let hook = {
+        id: '1',
+        type: 'before',
+        params: {}
+      };
+
+      try {
+        var returnedHook = hasRoleOrRestrict(options)(hook);
+        expect(returnedHook).to.deep.equal(hook);
+      }
+      catch(error) {
+        console.log("error", error);
+        // It should never get here
+        expect(true).to.equal(false);
+      }
+    });
+  });
+
+  describe('when user does not exist', () => {
+    it('should merge the restriction in to the query and call find', () => {
+      let hook = {
+        app: {
+          service: mockService,
+          get: function() {}
+        },
+        type: 'before',
+        params: {
+          provider: 'rest',
+          query: {author: "James"}
+        }
+      };
+
+      hook = hasRoleOrRestrict({ roles: ['admin'], restrict: {approved: true} }).call(mockService, hook);
+      expect(mockFind).to.be.calledWith({ query: {author: "James", approved: true} }, { provider: undefined, query: { author: "James" } });
+    });
+
+    it('if hook.id is set, merge the restriction and the id into the query and call find', () => {
+      let hook = {
+        id: '525235',
+        app: {
+          service: MockService,
+          get: function() {}
+        },
+        type: 'before',
+        params: {
+          provider: 'rest'
+        }
+      };
+
+      hook = hasRoleOrRestrict({ roles: ['admin'], restrict: {approved: true}, idField: '_id'}).call(mockService, hook);
+      expect(mockFind).to.be.calledWith({ query:{'_id': "525235", approved: true} }, { provider: undefined });
+    });
+  });
+
+  describe('when user exists', () => {
+    let hook;
+
+    beforeEach(() => {
+      hook = {
+        id: '1',
+        type: 'before',
+        params: {
+          provider: 'rest',
+          user: {
+            _id: '1',
+            roles: ['admin']
+          }
+        },
+        app: {
+          get: function() { return {}; }
+        }
+      };
+    });
+
+    describe('when user is missing idField', () => {
+      it('throws an error', () => {
+        hook.params.user = {};
+
+        try {
+          hasRoleOrRestrict(options)(hook);
+        }
+        catch(error) {
+          expect(error).to.not.equal(undefined);
+        }
+      });
+    });
+
+    describe('when user is missing fieldName', () => {
+      it('throws a Forbidden error', () => {
+        hook.params.user = { _id: '1' };
+
+        try {
+          hasRoleOrRestrict(options)(hook);
+        }
+        catch(error) {
+          expect(error.code).to.equal(403);
+        }
+      });
+    });
+
+    describe('when user is missing the role', () => {
+      beforeEach(() => {
+        hook.params.user = {
+          '_id': '1',
+          roles: ['user']
+        };
+      });
+
+      it('should merge the restriction in to the query and call find', () => {
+        let hook = {
+          app: {
+            service: mockService,
+            get: function() {}
+          },
+          type: 'before',
+          params: {
+            provider: 'rest',
+            query: {author: "James"}
+          }
+        };
+
+        hook = hasRoleOrRestrict({ roles: ['admin'], restrict: {approved: true} }).call(mockService, hook);
+        expect(mockFind).to.be.calledWith({ query: {author: "James", approved: true} }, { provider: undefined, query: { author: "James" } });
+      });
+
+      it('if hook.id is set, merge the restriction and the id into the query and call find', () => {
+        let hook = {
+          id: '525235',
+          app: {
+            service: MockService,
+            get: function() {}
+          },
+          type: 'before',
+          params: {
+            provider: 'rest'
+          }
+        };
+
+        hook = hasRoleOrRestrict({ roles: ['admin'], restrict: {approved: true}, idField: '_id'}).call(mockService, hook);
+        expect(mockFind).to.be.calledWith({ query:{'_id': "525235", approved: true} }, { provider: undefined });
+      });
+
+      describe('when owner option enabled', () => {
+        beforeEach(() => {
+          options.owner = true;
+        });
+
+        describe('when not called with an id', () => {
+          it('throws an error', () => {
+            hook.id = undefined;
+
+            try {
+              hasRoleOrRestrict(options)(hook);
+            }
+            catch(error) {
+              expect(error).to.not.equal(undefined);
+            }
+          });
+        });
+
+        describe('when resource is missing owner id', () => {
+          it('returns a Forbidden error', done => {
+            options.ownerField = 'user';
+            let fn = hasRoleOrRestrict(options);
+
+            fn.call(MockService, hook).then(done).catch(error => {
+              expect(error.code).to.equal(403);
+              done();
+            });
+          });
+        });
+
+        describe('when user is not an owner', () => {
+          it('returns a Forbidden error', done => {
+            hook.params.user._id = '2';
+            let fn = hasRoleOrRestrict(options);
+
+            fn.call(MockService, hook).then(done).catch(error => {
+              expect(error.code).to.equal(403);
+              done();
+            });
+          });
+        });
+
+        describe('when user owns the resource', () => {
+          it('does nothing', done => {
+            let fn = hasRoleOrRestrict(options);
+
+            fn.call(MockService, hook).then(returnedHook => {
+              expect(returnedHook).to.deep.equal(hook);
+              done();
+            }).catch(done);
+          });
+        });
+      });
+    });
+
+    describe('when user has role', () => {
+      let hook;
+
+      beforeEach(() => {
+        hook = {
+          id: '1',
+          type: 'before',
+          params: {
+            provider: 'rest',
+            user: {
+              '_id': '1',
+              roles: ['admin']
+            },
+            query: {}
+          },
+          app: {
+            get: function() { return {}; }
+          }
+        };
+      });
+
+      it('does not throw an error using default options', () => {
+        try {
+          hasRoleOrRestrict(options)(hook);
+          expect(true).to.equal(true);
+        }
+        catch (e) {
+          // Should never get here
+          expect(true).to.equal(false);
+        }
+      });
+
+      it('does not throw an error when user role field is singular', () => {
+        hook.params.user.roles = 'admin';
+
+        try {
+          hasRoleOrRestrict(options)(hook);
+          expect(true).to.equal(true);
+        }
+        catch (e) {
+          // Should never get here
+          expect(true).to.equal(false);
+        }
+      });
+
+      it('does not throw an error using global auth config', () => {
+        hook.params.user.id = '2';
+        hook.params.user.role = 'admin';
+        hook.app.get = function() {
+          return { idField: 'id', ownerField: 'ownerId', fieldName: 'role' };
+        };
+
+        try {
+          hasRoleOrRestrict(options)(hook);
+          expect(true).to.equal(true);
+        }
+        catch (e) {
+          // Should never get here
+          expect(true).to.equal(false);
+        }
+      });
+
+      it('does not throw an error using custom options', () => {
+        hook.params.user.id = '2';
+        hook.params.user.permissions = ['super'];
+
+        try {
+          hasRoleOrRestrict({ roles: options.roles, idField: 'id', ownerField: 'ownerId', fieldName: 'permissions' })(hook);
+          expect(true).to.equal(true);
+        }
+        catch (e) {
+          // Should never get here
+          expect(true).to.equal(false);
+        }
+      });
+    });
+  });
+});

--- a/test/src/hooks/index.test.js
+++ b/test/src/hooks/index.test.js
@@ -41,4 +41,16 @@ describe('Auth hooks', () => {
   it('exposes verifyToken hook', () => {
     expect(typeof hooks.verifyToken).to.equal('function');
   });
+
+  it('exposes verifyOrRestrict hook', () => {
+    expect(typeof hooks.verifyOrRestrict).to.equal('function');
+  });
+
+  it('exposes populateOrRestrict hook', () => {
+    expect(typeof hooks.populateOrRestrict).to.equal('function');
+  });
+
+  it('exposes hasRoleOrRestrict hook', () => {
+    expect(typeof hooks.hasRoleOrRestrict).to.equal('function');
+  });
 });

--- a/test/src/hooks/populate-or-restrict.test.js
+++ b/test/src/hooks/populate-or-restrict.test.js
@@ -1,0 +1,129 @@
+import chai, { expect } from 'chai';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+import { populateOrRestrict } from '../../../src/hooks';
+
+chai.use(sinonChai);
+
+const fn = sinon.stub();
+const User = { name: 'Mary', '_id': 111 };
+const mockGetFailure = sinon.stub().returns(Promise.reject('Could not find user with that id'));
+const mockServiceFailure = sinon.stub().returns({
+  get: mockGetFailure
+});
+
+const mockFind = sinon.stub().returns(Promise.resolve([{text: 'test', approved: true}]));
+const mockService = {
+  find: mockFind
+};
+
+describe('populateOrRestrict', () => {
+  describe('when payload is missing', () => {
+    it('should merge the restriction in to the query and call find', () => {
+      let hook = {
+        app: {
+          service: mockService,
+          get: function() {}
+        },
+        type: 'before',
+        params: {
+          provider: 'rest',
+          query: {author: "James"}
+        }
+      };
+
+      hook = populateOrRestrict({ restrict: {approved: true} }).call(mockService, hook);
+      expect(mockFind).to.be.calledWith({ query: {author: "James", approved: true} }, { provider: undefined, query: { author: "James" } });
+    });
+
+    it('if hook.id is set, merge the restriction and the id into the query and call find', () => {
+      let hook = {
+        id: '525235',
+        app: {
+          service: mockService,
+          get: function() {}
+        },
+        type: 'before',
+        params: {
+          provider: 'rest'
+        }
+      };
+
+      hook = populateOrRestrict({ restrict: {approved: true}, idField: '_id'}).call(mockService, hook);
+      expect(mockFind).to.be.calledWith({ query:{'_id': "525235", approved: true} }, { provider: undefined });
+    });
+  });
+
+  describe('when no user is found', () => {
+    it('should merge the restriction in to the query and call find', () => {
+      let hook = {
+        app: {
+          service: mockService,
+          get: function() {}
+        },
+        type: 'before',
+        params: {
+          provider: 'rest',
+          query: {author: "James"}
+        }
+      };
+
+      hook = populateOrRestrict({ restrict: {approved: true} }).call(mockService, hook);
+      expect(mockFind).to.be.calledWith({ query: {author: "James", approved: true} }, { provider: undefined, query: { author: "James" } });
+    });
+
+    it('if hook.id is set, merge the restriction and the id into the query and call find', () => {
+      let hook = {
+        id: '525235',
+        app: {
+          service: mockService,
+          get: function() {}
+        },
+        type: 'before',
+        params: {
+          provider: 'rest'
+        }
+      };
+
+      hook = populateOrRestrict({ restrict: {approved: true}, idField: '_id'}).call(mockService, hook);
+      expect(mockFind).to.be.calledWith({ query:{'_id': "525235", approved: true} }, { provider: undefined });
+    });
+  });
+
+  describe('when user id is missing', () => {
+    it('does not do anything', done => {
+      let hook = {
+        type: 'before',
+        params: {
+          provider: 'rest',
+          payload: {
+            id: undefined
+          }
+        },
+        app: {
+          get: fn
+        }
+      };
+
+      populateOrRestrict({ restrict: {approved: true} })(hook).then(returnedHook => {
+        expect(hook).to.deep.equal(returnedHook);
+        done();
+      }).catch(done);
+    });
+  });
+
+  describe('when not called as a before hook', () => {
+    it('throws an error', () => {
+      let hook = {
+        type: 'after'
+      };
+
+      try {
+        populateOrRestrict({restrict: {approved: true} })(hook);
+      }
+      catch(error) {
+        expect(error).to.not.equal(undefined);
+      }
+    });
+  });
+});

--- a/test/src/hooks/populate-or-restrict.test.js
+++ b/test/src/hooks/populate-or-restrict.test.js
@@ -6,12 +6,6 @@ import { populateOrRestrict } from '../../../src/hooks';
 chai.use(sinonChai);
 
 const fn = sinon.stub();
-const User = { name: 'Mary', '_id': 111 };
-const mockGetFailure = sinon.stub().returns(Promise.reject('Could not find user with that id'));
-const mockServiceFailure = sinon.stub().returns({
-  get: mockGetFailure
-});
-
 const mockFind = sinon.stub().returns(Promise.resolve([{text: 'test', approved: true}]));
 const mockService = {
   find: mockFind
@@ -28,12 +22,12 @@ describe('populateOrRestrict', () => {
         type: 'before',
         params: {
           provider: 'rest',
-          query: {author: "James"}
+          query: {author: 'James'}
         }
       };
 
       hook = populateOrRestrict({ restrict: {approved: true} }).call(mockService, hook);
-      expect(mockFind).to.be.calledWith({ query: {author: "James", approved: true} }, { provider: undefined, query: { author: "James" } });
+      expect(mockFind).to.be.calledWith({ query: {author: 'James', approved: true} }, { provider: undefined, query: { author: 'James' } });
     });
 
     it('if hook.id is set, merge the restriction and the id into the query and call find', () => {
@@ -50,7 +44,7 @@ describe('populateOrRestrict', () => {
       };
 
       hook = populateOrRestrict({ restrict: {approved: true}, idField: '_id'}).call(mockService, hook);
-      expect(mockFind).to.be.calledWith({ query:{'_id': "525235", approved: true} }, { provider: undefined });
+      expect(mockFind).to.be.calledWith({ query:{'_id': '525235', approved: true} }, { provider: undefined });
     });
   });
 
@@ -64,12 +58,12 @@ describe('populateOrRestrict', () => {
         type: 'before',
         params: {
           provider: 'rest',
-          query: {author: "James"}
+          query: {author: 'James'}
         }
       };
 
       hook = populateOrRestrict({ restrict: {approved: true} }).call(mockService, hook);
-      expect(mockFind).to.be.calledWith({ query: {author: "James", approved: true} }, { provider: undefined, query: { author: "James" } });
+      expect(mockFind).to.be.calledWith({ query: {author: 'James', approved: true} }, { provider: undefined, query: { author: 'James' } });
     });
 
     it('if hook.id is set, merge the restriction and the id into the query and call find', () => {
@@ -86,7 +80,7 @@ describe('populateOrRestrict', () => {
       };
 
       hook = populateOrRestrict({ restrict: {approved: true}, idField: '_id'}).call(mockService, hook);
-      expect(mockFind).to.be.calledWith({ query:{'_id': "525235", approved: true} }, { provider: undefined });
+      expect(mockFind).to.be.calledWith({ query:{'_id': '525235', approved: true} }, { provider: undefined });
     });
   });
 

--- a/test/src/hooks/verify-token-or-restrict.test.js
+++ b/test/src/hooks/verify-token-or-restrict.test.js
@@ -1,0 +1,203 @@
+import jwt from 'jsonwebtoken';
+import { verifyOrRestrict } from '../../../src/hooks';
+
+import chai, { expect } from 'chai';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+chai.use(sinonChai);
+
+const mockFind = sinon.stub().returns(Promise.resolve([{text: 'test', approved: true}]));
+const mockService = {
+  find: mockFind
+};
+
+describe('verifyOrRestrict', () => {
+  describe('when not called as a before hook', () => {
+    it('throws an error', () => {
+      let hook = {
+        type: 'after'
+      };
+
+      try {
+        verifyOrRestrict()(hook);
+      }
+      catch(error) {
+        expect(error).to.not.equal(undefined);
+      }
+    });
+  });
+
+  describe('when provider does not exist', () => {
+    it('does not do anything', () => {
+      let hook = {
+        type: 'before',
+        params: {}
+      };
+
+      try {
+        var returnedHook = verifyOrRestrict()(hook);
+        expect(hook).to.deep.equal(returnedHook);
+      }
+      catch(error) {
+        // It should never get here
+        expect(false).to.equal(true);
+      }
+    });
+  });
+
+  describe('when token does not exist', () => {
+    it('should merge the restriction in to the query and call find', () => {
+      let hook = {
+        app: {
+          service: mockService,
+          get: function() {}
+        },
+        type: 'before',
+        params: {
+          provider: 'rest',
+          query: {author: "James"}
+        }
+      };
+
+      hook = verifyOrRestrict({ restrict: {approved: true} }).call(mockService, hook);
+      expect(mockFind).to.be.calledWith({ query: {author: "James", approved: true} }, { provider: undefined, query: { author: "James" } });
+    });
+
+    it('if hook.id is set, merge the restriction and the id into the query and call find', () => {
+      let hook = {
+        id: '525235',
+        app: {
+          service: mockService,
+          get: function() {}
+        },
+        type: 'before',
+        params: {
+          provider: 'rest'
+        }
+      };
+
+      hook = verifyOrRestrict({ restrict: {approved: true}, idField: '_id'}).call(mockService, hook);
+      expect(mockFind).to.be.calledWith({ query:{'_id': "525235", approved: true} }, { provider: undefined });
+    });
+  });
+
+  describe('when token exists', () => {
+    let hook;
+
+    beforeEach(() => {
+      hook = {
+        type: 'before',
+        params: {
+          provider: 'rest',
+          token: 'valid_token'
+        },
+        app: {
+          get: function() { return {}; }
+        }
+      };
+    });
+
+    describe('when secret is missing', () => {
+      it('throws an error', () => {
+        try {
+          verifyOrRestrict()(hook);
+        }
+        catch(error) {
+          expect(error).to.not.equal(undefined);
+        }
+      });
+    });
+
+    describe('when secret is present', () => {
+      beforeEach(() => {
+        hook.app.get = function() {
+          return {
+            token: {
+              secret: 'secret'
+            }
+          };
+        };
+      });
+
+      describe('when token is invalid', () => {
+        it('returns a not authenticated error', done => {
+          hook.params.token = 'invalid';
+
+          verifyOrRestrict()(hook).then(done).catch(error => {
+            expect(error.code).to.equal(401);
+            done();
+          });
+        });
+      });
+
+      describe('when token is valid', () => {
+        it('returns an error when options are not consistent', done => {
+          let jwtOptions = {
+            algorithm: 'HS512'
+          };
+
+          hook.app.get = function() {
+            return {
+              token: {
+                secret: 'secret',
+                algorithm: 'HS384'
+              }
+            };
+          };
+
+          hook.params.token = jwt.sign({ id: 1 }, 'secret', jwtOptions);
+
+          verifyOrRestrict()(hook).then(() => {
+            // should never get here
+            expect(false).to.equal(true);
+            done();
+          }).catch(error => {
+            expect(error.code).to.equal(401);
+            done();
+          });
+        });
+
+        it('adds token payload to params using options from global auth config', done => {
+          let jwtOptions = {
+            issuer: 'custom',
+            audience: 'urn:feathers',
+            algorithm: 'HS512',
+            expiresIn: '1h' // 1 hour
+          };
+
+          hook.app.get = function() {
+            return {
+              token: {
+                secret: 'secret',
+                issuer: 'custom',
+                audience: 'urn:feathers',
+                algorithm: 'HS512'
+              }
+            };
+          };
+
+          hook.params.token = jwt.sign({ id: 1 }, 'secret', jwtOptions);
+
+          verifyOrRestrict()(hook).then(hook => {
+            expect(hook.params.payload.id).to.equal(1);
+            done();
+          }).catch(done);
+        });
+
+        it('adds token payload to params using custom options', done => {
+          let jwtOptions = {
+            issuer: 'feathers',
+            expiresIn: '1h' // 1 hour
+          };
+
+          hook.params.token = jwt.sign({ id: 1 }, 'custom secret', jwtOptions);
+
+          verifyOrRestrict({ secret: 'custom secret' })(hook).then(hook => {
+            expect(hook.params.payload.id).to.equal(1);
+            done();
+          }).catch(done);
+        });
+      });
+    });
+  });
+});

--- a/test/src/hooks/verify-token-or-restrict.test.js
+++ b/test/src/hooks/verify-token-or-restrict.test.js
@@ -55,12 +55,12 @@ describe('verifyOrRestrict', () => {
         type: 'before',
         params: {
           provider: 'rest',
-          query: {author: "James"}
+          query: {author: 'James'}
         }
       };
 
       hook = verifyOrRestrict({ restrict: {approved: true} }).call(mockService, hook);
-      expect(mockFind).to.be.calledWith({ query: {author: "James", approved: true} }, { provider: undefined, query: { author: "James" } });
+      expect(mockFind).to.be.calledWith({ query: {author: 'James', approved: true} }, { provider: undefined, query: { author: 'James' } });
     });
 
     it('if hook.id is set, merge the restriction and the id into the query and call find', () => {
@@ -77,7 +77,7 @@ describe('verifyOrRestrict', () => {
       };
 
       hook = verifyOrRestrict({ restrict: {approved: true}, idField: '_id'}).call(mockService, hook);
-      expect(mockFind).to.be.calledWith({ query:{'_id': "525235", approved: true} }, { provider: undefined });
+      expect(mockFind).to.be.calledWith({ query:{'_id': '525235', approved: true} }, { provider: undefined });
     });
   });
 


### PR DESCRIPTION
Often developers want to allow unauthenticated users or visitors to query data from a table but place restrictions on what type of data in the table is returned based on information in each row. This allows you to merge a restriction query into the query params to limit of the scope of what an unauthenticated user may search for.

Adds 3 hooks:

- verifyOrRestrict({ restrict: {approved: true} })
- populateOrRestrict({ restrict: {approved: true} })
- hasRoleOrRestrict({roles: ['admin'], restrict: {approved: true} })

NOTICE: Currently does not filter direct ids through the get method