### PR TITLE
RestrictToOwner now takes an array

### DIFF
--- a/src/hooks/restrict-to-owner.js
+++ b/src/hooks/restrict-to-owner.js
@@ -28,7 +28,7 @@ export default function(options = {}){
     }
 
     options = Object.assign({}, defaults, hook.app.get('auth'), options);
-    
+
     const id = hook.params.user[options.idField];
 
     if (id === undefined) {
@@ -51,12 +51,17 @@ export default function(options = {}){
 
         let field = data[options.ownerField];
 
-        // Handle nested Sequelize or Mongoose models 
+        // Handle nested Sequelize or Mongoose models
         if (isPlainObject(field)) {
           field = field[options.idField];
         }
 
-        if ( field === undefined || field.toString() !== id.toString() ) {
+        if (Array.isArray(field)) {
+          const fieldArray = field.map(idValue => idValue.toString());
+          if (fieldArray.length === 0 || fieldArray.indexOf(id.toString()) < 0) {
+            reject(new errors.Forbidden('You do not have the permissions to access this.'));
+          }
+        } else if ( field === undefined || field.toString() !== id.toString() ) {
           reject(new errors.Forbidden('You do not have the permissions to access this.'));
         }
 


### PR DESCRIPTION
Basic use case:
- You have a model (let's call it a team model) with an array ids as admins
- You want to check who has permission to modify the team by checking the authenticated user against the admin array

If you guys don't think this type of functionality is appropriate in the bundled hooks, I understand. Just thought I would throw it out there since I just ran into a use case for this functionality in the project I'm currently working on. 