### PR TITLE
overwrite password check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,5 +27,8 @@ node_modules
 # Users Environment Variables
 .lock-wscript
 
+# Temp files
+*~
+
 lib/
 data.db


### PR DESCRIPTION
This is to allow custom password encryption strategies like:
```
'use strict';
const authentication = require('feathers-authentication');
const crypto = require('crypto');
    
module.exports = function() {
  const app = this;
    
  let config = app.get('auth');
    
  function verifyPassword(password, user, done) {
      var shasum=crypto.createHash("sha1");
      shasum.update(app.get("salt")+"&&&&&"+password);
      var p=shasum.digest("hex");
      return done(null, p===user.password);
  }
  config.local.verifyPassword = verifyPassword;
  app.set('auth', config);
  app.configure(authentication(config));
};

```