### PR TITLE
Attempt to get token right away.

### DIFF
--- a/src/client/index.js
+++ b/src/client/index.js
@@ -28,6 +28,7 @@ export default function(opts = {}) {
 
     getJWT(config.tokenKey, config.cookie, this.get('storage')).then(token => {
       app.set('token', token);
+      app.get('storage').setItem(config.tokenKey, token);
     });
 
     app.authenticate = function(options = {}) {

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -26,6 +26,10 @@ export default function(opts = {}) {
       app.set('storage', getStorage(config.storage));
     }
 
+    getJWT(config.tokenKey, config.cookie, this.get('storage')).then(token => {
+      app.set('token', token);
+    });
+
     app.authenticate = function(options = {}) {
       const storage = this.get('storage');
       let getOptions = Promise.resolve(options);


### PR DESCRIPTION
This makes it so that we don’t have to wait for an async response in order to start making authenticated requests.