### PR TITLE
Prevent redirect on successful auth/token login.

### DIFF
--- a/src/middleware/express/login-success.js
+++ b/src/middleware/express/login-success.js
@@ -4,7 +4,7 @@
 
 export default function loginSuccess(options = {}) {
   return function(req, res, next) {
-    if (options.successRedirect !== undefined) {      
+    if (options.successRedirect !== undefined && options.successRedirect !== null) {      
       return res.redirect(options.successRedirect);
     }
     


### PR DESCRIPTION
Since the default value for successRedirect is null, we have to check for `null` to prevent auth/token logins from breaking.  Otherwise, they get redirected to `/auth/null`.