### PR TITLE
Manually supply an endpoint to the Client authenticate() method

### DIFF
--- a/src/client/index.js
+++ b/src/client/index.js
@@ -52,7 +52,9 @@ export default function(opts = {}) {
       return getOptions.then(options => {
         let endPoint;
 
-        if (options.type === 'local') {
+        if (options.endpoint) {
+          endPoint = options.endpoint;
+        } else if (options.type === 'local') {
           endPoint = config.localEndpoint;
         } else if (options.type === 'token') {
           endPoint = config.tokenEndpoint;


### PR DESCRIPTION
By simply providing the ability to specify the endpoint in the client authenticate method, it allows the ability for mobile users to authenticate via a native mobile Facebook SDK for example, and then post that Facebook access_token to Feathers to do it's thing via the FacebookTokenStrategy method.

eg. from react-native, I've just authenticated natively via the Facebook SDK, which has given me an access token:

```
app.authenticate({
   type: 'token',
   endpoint: '/auth/facebook',
   access_token: accessToken
});
```