### PR TITLE
hashPassword fall-through if there's no password

### DIFF
--- a/src/hooks/hash-password.js
+++ b/src/hooks/hash-password.js
@@ -34,11 +34,7 @@ export default function (options = {}) {
     }
 
     if (password === undefined) {
-      if (!hook.params.provider) {
-        return hook;
-      }
-
-      throw new errors.BadRequest(`'${options.passwordField}' field is missing.`);
+      return hook;
     }
 
     return new Promise(function (resolve, reject) {

--- a/src/hooks/hash-password.js
+++ b/src/hooks/hash-password.js
@@ -1,6 +1,4 @@
-import errors from 'feathers-errors';
 import bcrypt from 'bcryptjs';
-
 
 const defaults = { passwordField: 'password' };
 


### PR DESCRIPTION
The user should have already run a `requireAuth` hook by this point. Fixes https://github.com/feathersjs/feathers-authentication/issues/286