### PR TITLE
0.8 - OAuth fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "bcryptjs": "^2.3.0",
     "cookie-parser": "^1.4.3",
     "debug": "^2.2.0",
+    "feathers-commons": "^0.7.5",
     "feathers-errors": "^2.4.0",
     "jsonwebtoken": "^7.1.9",
     "lodash.intersection": "^4.4.0",

--- a/src/base.js
+++ b/src/base.js
@@ -1,0 +1,87 @@
+import Debug from 'debug';
+import jwt from 'jsonwebtoken';
+
+const debug = Debug('feathers-authentication');
+
+export default class Authentication {
+  constructor(app, options) {
+    this.options = options;
+    this.app = app;
+    this._middleware = [];
+  }
+
+  use(... middleware) {
+    const mapped = middleware.map(current =>
+      current.call(this.app, this.options)
+    );
+
+    this._middleware = this._middleware.concat(mapped);
+
+    return this;
+  }
+
+  authenticate(data) {
+    let promise = Promise.resolve(data);
+
+    debug('Authenticating', data);
+
+    this._middleware.forEach(middleware =>
+      promise = promise.then(data =>
+        middleware.call(this.app, data, this.options)
+      )
+    );
+
+    return promise;
+  }
+
+  verifyJWT(data, params) {
+    const settings = Object.assign({}, this.options.jwt, params);
+    const token = typeof data === 'string' ? data : data.token;
+    const { secret } = this.options;
+
+    debug('Verifying token', token);
+
+    return new Promise((resolve, reject) => {
+      jwt.verify(token, secret, settings, (error, payload) => {
+        if(error) {
+          debug('Error verifying token', error);
+          return reject(error);
+        }
+
+        debug('Verified token with payload', payload);
+        resolve({ token, payload });
+      });
+    });
+  }
+
+  createJWT(data, params) {
+    const settings = Object.assign({}, this.options.jwt, params);
+    const { secret } = this.options;
+
+    if(data.iss) {
+      delete settings.issuer;
+    }
+
+    if(data.sub) {
+      delete settings.subject;
+    }
+
+    if(data.exp) {
+      delete settings.expiresIn;
+    }
+
+    return new Promise((resolve, reject) => {
+      debug('Creating JWT using options', settings);
+
+      jwt.sign(data, secret, settings, (error, token) => {
+        if (error) {
+          debug('Error signing JWT', error);
+          return reject(error);
+        }
+
+        debug('New JWT issued with payload', data);
+        return resolve({ token, payload: data });
+      });
+    });
+  }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -51,7 +51,7 @@ const defaults = {
   oauth2: {
     // service: '/auth/facebook', // required - the service path or initialized service
     passReqToCallback: true, // optional - whether request should be passed to callback
-    // callbackUrl: 'callback', // optional - the callback url, by default this gets set to /<service>/callback
+    // callbackURL: 'callback', // optional - the callback url, by default this gets set to /<service>/callback
     permissions: {
       state: true,
       session: false

--- a/src/options.js
+++ b/src/options.js
@@ -1,0 +1,59 @@
+import merge from 'lodash.merge';
+
+// Options that apply to any provider
+export const defaults = {
+  header: 'Authorization',
+  setupMiddleware: true, // optional - to setup middleware yourself set to false.
+  cookie: { // Used for redirects, server side rendering and OAuth
+    enabled: false, // Set to true to enable all cookies
+    name: 'feathers-jwt',
+    httpOnly: true,
+    maxAge: '1d',
+    secure: true
+  },
+  jwt: {
+    issuer: 'feathers',
+    algorithm: 'HS256',
+    expiresIn: '1d'
+  },
+  token: {
+    name: 'token', // optional
+    service: '/auth/token', // optional string or Service
+    subject: 'auth', // optional
+    issuer: 'feathers', // optional
+    algorithm: 'HS256', // optional
+    expiresIn: '1d', // optional
+    secret: null, // required
+    successRedirect: null, // optional - no default. If set the default success handler will redirect to location
+    failureRedirect: null, // optional - no default. If set the default success handler will redirect to location
+    successHandler: null // optional - a middleware to handle things once authentication succeeds
+  },
+  local: {
+    service: '/auth/local', // optional string or Service
+    successRedirect: null, // optional - no default. If set the default success handler will redirect to location
+    failureRedirect: null, // optional - no default. If set the default success handler will redirect to location
+    successHandler: null, // optional - a middleware to handle things once authentication succeeds
+    passReqToCallback: true, // optional - whether request should be passed to callback
+    session: false // optional - whether we should use a session
+  },
+  user: {
+    service: '/users', // optional string or Service
+    idField: '_id', // optional
+    usernameField: 'email', // optional
+    passwordField: 'password', // optional
+    crypto: 'bcryptjs'
+  },
+  oauth2: {
+    // service: '/auth/facebook', // required - the service path or initialized service
+    passReqToCallback: true, // optional - whether request should be passed to callback
+    // callbackUrl: 'callback', // optional - the callback url, by default this gets set to /<service>/callback
+    permissions: {
+      state: true,
+      session: false
+    }
+  }
+};
+
+export default function(... otherOptions) {
+  return merge({}, defaults, ... otherOptions);
+}

--- a/src/services/authentication.js
+++ b/src/services/authentication.js
@@ -1,0 +1,19 @@
+export class Authentication {
+  create(data, params) {
+    if(params.provider && !params.authentication) {
+      return Promise.reject(new Error(`External ${params.provider} requests need to run through an authentication provider`));
+    }
+
+    return this.authentication.createJWT(data.payload);
+  }
+
+  remove(id, params) {
+    const token = id !== null ? id : params.token;
+
+    return this.authentication.verifyJWT({ token });
+  }
+
+  setup(app) {
+    this.authentication = app.authentication;
+  }
+}

--- a/src/services/oauth2.js
+++ b/src/services/oauth2.js
@@ -38,7 +38,7 @@ export class OAuth2Service {
   updateUser(user, data) {
     const idField = this.options.user.idField;
     const id = user[idField];
-    const userService = typeof this._userService === 'string' ? this.app.service(this._userService) : this._userService;
+    const userService = this.getUserService();
 
     debug(`Updating user: ${id}`);
 
@@ -52,7 +52,7 @@ export class OAuth2Service {
   createUser(data) {
     const provider = this.options.provider;
     const id = data[`${provider}Id`];
-    const userService = typeof this._userService === 'string' ? this.app.service(this._userService) : this._userService;
+    const userService = this.getUserService();
     debug(`Creating new user with ${provider}Id: ${id}`);
 
     return userService.create(data, { oauth: true });
@@ -65,7 +65,7 @@ export class OAuth2Service {
       // facebookId: profile.id
       [`${options.provider}Id`]: profile.id
     };
-    const userService = typeof this._userService === 'string' ? this.app.service(this._userService) : this._userService;
+    const userService = this.getUserService();
 
     // Find or create the user since they could have signed up via facebook.
     userService
@@ -93,6 +93,14 @@ export class OAuth2Service {
       .catch(error => error ? done(error) : done(null, error));
   }
 
+  getUserService(){
+    return typeof this._userService === 'string' ? this.app.service(this._userService) : this._userService;
+  }
+
+  getTokenService(){
+    return typeof this._tokenService === 'string' ? this.app.service(this._tokenService) : this._tokenService;
+  }
+
   // GET /auth/facebook
   find(params) {
     // Authenticate via your provider. This will redirect you to authorize the application.
@@ -103,7 +111,7 @@ export class OAuth2Service {
   get(id, params) {
     // Make sure the provider plugin name doesn't overwrite the OAuth provider name.
     delete params.provider;
-    const tokenService = typeof this._tokenService === 'string' ? this.app.service(this._tokenService) : this._tokenService;
+    const tokenService = this.getTokenService();
     const options = Object.assign({}, this.options, params);
 
     if (`/${stripSlashes(options.service)}/${id}` !== options.callbackURL) {
@@ -141,7 +149,7 @@ export class OAuth2Service {
   // This is for mobile token based authentication
   create(data, params) {
     const options = this.options;
-    const tokenService = typeof this._tokenService === 'string' ? this.app.service(this._tokenService) : this._tokenService;
+    const tokenService = this.getTokenService();
 
     if (!options.tokenStrategy) {
       return Promise.reject(new errors.MethodNotAllowed());

--- a/src/services/oauth2.js
+++ b/src/services/oauth2.js
@@ -98,6 +98,8 @@ export class OAuth2Service {
 
   // For GET /auth/facebook/callback
   get(id, params) {
+    // Make sure the provider plugin name doesn't overwrite the OAuth provider name.
+    delete params.provider;
     const options = Object.assign({}, this.options, params);
 
     if (`${options.service}/${id}` !== options.callbackUrl) {

--- a/src/services/oauth2.js
+++ b/src/services/oauth2.js
@@ -230,7 +230,11 @@ export default function init (options){
   }
 
   if (!options.service) {
-    throw new Error(`You need to provide an 'service' for your ${options.provider} provider. This can either be a string or an initialized service.`);
+    throw new Error(`You need to provide an 'service' for your ${options.provider} OAuth provider. This can either be a string or an initialized service.`);
+  }
+
+  if (!options.successHandler && !options.successRedirect) {
+    throw new Error(`You need to provide a 'successRedirect' URL for your ${options.provider} OAuth provider when using the default successHandler.`);
   }
 
   if (!options.strategy) {

--- a/src/services/oauth2.js
+++ b/src/services/oauth2.js
@@ -102,7 +102,7 @@ export class OAuth2Service {
     delete params.provider;
     const options = Object.assign({}, this.options, params);
 
-    if (`${options.service}/${id}` !== options.callbackUrl) {
+    if (`/${stripSlashes(options.service)}/${id}` !== options.callbackURL) {
       return Promise.reject(new errors.NotFound());
     }
 

--- a/src/token/from-request.js
+++ b/src/token/from-request.js
@@ -1,0 +1,36 @@
+import Debug from 'debug';
+
+const debug = Debug('feathers-authentication:token:from-request');
+
+export default function(options) {
+  const header = options.header;
+
+  if (!header) {
+    throw new Error(`'header' property must be set in authentication options`);
+  }
+
+  return function fromRequest(data) {
+    if (typeof data === 'object' && data.headers) {
+      const req = data;
+
+      debug('Parsing token from request');
+
+      // Normalize header capitalization the same way Node.js does
+      let token = req.headers && req.headers[header.toLowerCase()];
+
+      // Check the header for the token (preferred method)
+      if (token) {
+        // if the value contains "bearer" or "Bearer" then cut that part out
+        if (/bearer/i.test(token)) {
+          token = token.split(' ')[1];
+        }
+
+        debug('Token found in header');
+      }
+
+      return Promise.resolve({ token, req });
+    }
+
+    return Promise.resolve(data);
+  };
+}

--- a/src/token/index.js
+++ b/src/token/index.js
@@ -1,0 +1,11 @@
+import fromRequest from './from-request';
+import verifyToken from './verify-token';
+import populateUser from './populate-user';
+
+export default {
+  fromRequest, verifyToken, populateUser
+};
+
+export const authMiddleware = [
+  fromRequest, verifyToken, populateUser
+];

--- a/src/token/populate-user.js
+++ b/src/token/populate-user.js
@@ -1,0 +1,39 @@
+import Debug from 'debug';
+
+const debug = Debug('feathers-authentication:token:populate-user');
+
+export default function(options) {
+  const app = this;
+  const { user } = options;
+
+  if(!user.service) {
+    throw new Error(`'user.service' needs to be set in authentication options`);
+  }
+
+  return function populateUser(data) {
+    const service = typeof user.service === 'string' ? app.service(user.service) : user.service;
+    const idField = user.idField || service.id;
+
+    if(typeof idField !== 'string') {
+      throw new Error(`'user.idField' needs to be set in authentication options or the '${user.service}' service needs to provide an 'id' field.`);
+    }
+
+    if(typeof service.get !== 'function') {
+      throw new Error(`'user.service' does not support a 'get' method necessary for populateUser.`);
+    }
+
+    if(!data || !data.payload || data.payload[idField] === undefined) {
+      return Promise.resolve(data);
+    }
+
+    const id = data.payload[idField];
+
+    debug(`Populating user ${id}`);
+
+    return service.get(id).then(result => {
+      const user = result.toJSON ? result.toJSON() : result;
+
+      return Object.assign({}, data, { user });
+    });
+  };
+}

--- a/src/token/verify-token.js
+++ b/src/token/verify-token.js
@@ -1,0 +1,19 @@
+import Debug from 'debug';
+
+const debug = Debug('feathers-authentication:token:verifyToken');
+
+export default function() {
+  return function verifyToken(data) {
+    const token = typeof data === 'string' ? data : (data && data.token);
+    const app = this;
+
+    if(token) {
+      debug('Verifying token', token);
+
+      return app.authentication.verifyJWT(token)
+        .then(result => Object.assign({ authenticated: true }, data, result));
+    }
+
+    return Promise.resolve(data);
+  };
+}

--- a/test/src/base.test.js
+++ b/test/src/base.test.js
@@ -1,0 +1,84 @@
+import { expect } from 'chai';
+import Authentication from '../../src/base';
+import getOptions from '../../src/options';
+
+function timeout(callback, timeout) {
+  return new Promise(resolve =>
+    setTimeout(() => resolve(callback()), timeout)
+  );
+}
+
+describe('Feathers Authentication Base Class', () => {
+  const original = { name: 'Feathers' };
+  const app = {};
+  const options = getOptions({
+    secret: 'supersecret'
+  });
+  const auth = new Authentication(app, options);
+
+  auth.use(function() {
+    return function(data) {
+      expect(this).to.equal(app);
+      expect(data).to.deep.equal(original);
+      data.firstRan = true;
+
+      return data;
+    };
+  });
+
+  it('.authenticate runs middleware', () => {
+    expect(auth.use(function(opts) {
+      expect(opts).to.deep.equal(options);
+
+      return function(data) {
+        expect(data).to.deep
+          .equal(Object.assign({ firstRan: true }, original));
+
+        return new Promise(resolve =>
+          setTimeout(() => resolve(Object.assign({
+            secondRan: true
+          }, data)), 100)
+        );
+      };
+    })).to.equal(auth);
+
+    return auth.authenticate(original).then(result =>
+      expect(result).to.deep.equal({
+        secondRan: true,
+        name: 'Feathers',
+        firstRan: true
+      })
+    );
+  });
+
+  it('create and verify', () => {
+    return auth.createJWT({
+      name: 'Eric'
+    }).then(data =>
+      auth.verifyJWT(data).then(result => {
+        const { payload } = result;
+        expect(payload.name).to.equal('Eric');
+        expect(payload.exp);
+        expect(payload.iss).to.equal('feathers');
+      })
+    );
+  });
+
+  it('verify errors with malformed token', () => {
+    auth.verifyJWT('invalid token').catch(e =>
+      expect(e.message).to.equal('jwt mlaformed')
+    );
+  });
+
+  it('create can set options and verify fails with expired token', () => {
+    return auth.createJWT({
+      name: 'Eric'
+    }, {
+      expiresIn: '50ms'
+    }).then(data =>
+      timeout(() => auth.verifyJWT(data), 100)
+    ).catch(error =>
+      expect(error.message).to.equal('jwt expired')
+    );
+  });
+});

--- a/test/src/index.test.js
+++ b/test/src/index.test.js
@@ -207,7 +207,7 @@ describe('Feathers Authentication', () => {
         const options = {
           token: {
             secret: 'secret'
-          } 
+          }
         };
 
         app = feathers()
@@ -275,7 +275,7 @@ describe('Feathers Authentication', () => {
         const options = {
           token: {
             secret: 'secret'
-          } 
+          }
         };
 
         app = feathers()
@@ -302,7 +302,7 @@ describe('Feathers Authentication', () => {
         const options = {
           token: {
             secret: 'secret'
-          } 
+          }
         };
 
         app = feathers()
@@ -338,7 +338,7 @@ describe('Feathers Authentication', () => {
         setupMiddleware: false,
         token: {
           secret: 'secret'
-        } 
+        }
       };
 
       app = feathers()

--- a/test/src/services/oauth2.test.js
+++ b/test/src/services/oauth2.test.js
@@ -1,4 +1,5 @@
 import { OAuth2Service as oauth2 } from '../../../src';
+import { normalizeCallbackURL } from '../../../src/services/oauth2';
 // import feathers from 'feathers';
 // import hooks from 'feathers-hooks';
 // import rest from 'feathers-rest';
@@ -16,6 +17,14 @@ describe('service:oauth2', () => {
   it('exposes the raw Service class', () => {
     expect(typeof oauth2.Service).to.equal('function');
     expect(oauth2.Service.name).to.equal('OAuth2Service');
+  });
+
+  it('assures that callbackURL is absolute or relative to root', () => {
+    expect(normalizeCallbackURL(undefined, 'auth/github')).to.equal('/auth/github/callback');
+    expect(normalizeCallbackURL(undefined, '/auth/github')).to.equal('/auth/github/callback');
+    expect(normalizeCallbackURL('test', '/auth/github')).to.equal('/test');
+    expect(normalizeCallbackURL('/auth/github/custom', '/auth/github')).to.equal('/auth/github/custom');
+    expect(normalizeCallbackURL('http://feathersjs.com/callback', '/auth/github')).to.equal('http://feathersjs.com/callback');
   });
 
   describe('config options', () => {

--- a/test/src/token/from-request.test.js
+++ b/test/src/token/from-request.test.js
@@ -1,0 +1,52 @@
+import { expect } from 'chai';
+import feathers from 'feathers';
+import authentication from '../../../src';
+import fromRequest from '../../../src/token/from-request';
+
+describe('Token Middleware fromRequest', () => {
+  const app = feathers()
+    .configure(authentication({
+      secret: 'supersecrect'
+    }).use(fromRequest));
+  const auth = app.authentication;
+
+  it('throws an error when header name is not set', () => {
+    try {
+      fromRequest({});
+    } catch(e) {
+      expect(e.message).to.equal(`'header' property must be set in authentication options`);
+    }
+  });
+
+  it('passes through when it is not a request object', () => {
+    auth.authenticate('testtoken').then(data =>
+      expect(data).to.equal('testtoken')
+    );
+  });
+
+  it('parses basic authorization header', () => {
+    const mockRequest = {
+      headers: {
+        authorization: 'sometoken'
+      }
+    };
+
+    return auth.authenticate(mockRequest).then(data => {
+      expect(data.req).to.equal(mockRequest);
+      expect(data.token).to.equal('sometoken');
+    });
+  });
+
+  it('parses `Bearer` authorization header', () => {
+    const mockRequest = {
+      headers: {
+        authorization: 'BeaRer sometoken'
+      }
+    };
+
+    return auth.authenticate(mockRequest).then(data => {
+      expect(data.req).to.equal(mockRequest);
+      expect(data.token).to.equal('sometoken');
+    });
+  });
+});

--- a/test/src/token/populate-user.test.js
+++ b/test/src/token/populate-user.test.js
@@ -1,0 +1,53 @@
+import { expect } from 'chai';
+import feathers from 'feathers';
+import authentication from '../../../src';
+import populateUser from '../../../src/token/populate-user';
+
+describe('Token Middleware fromRequest', () => {
+  const app = feathers()
+    .configure(authentication({
+      secret: 'supersecrect',
+      user: {
+        idField: 'name'
+      }
+    }).use(populateUser))
+    .use('/users', {
+      get(name) {
+        if(name === 'error') {
+          return Promise.reject(new Error('User not found'));
+        }
+
+        return Promise.resolve({ name, username: `Test ${name}` });
+      }
+    });
+  const auth = app.authentication;
+
+  it('populates the user from id in payload', () => {
+    auth.authenticate({
+      payload: { name: 'testing' }
+    }).then(data =>
+      expect(data.user).to.deep.equal({
+        name: 'testing',
+        username: 'Test testing'
+      })
+    );
+  });
+
+  it('errors when id exists but user is not found', () => {
+    auth.authenticate({
+      payload: { name: 'error' }
+    }).catch(error =>
+      expect(error.message).to.equal('User not found')
+    );
+  });
+
+  it('does nothing when payload does not exist', () => {
+    const original = {
+      dummy: true
+    };
+
+    auth.authenticate(original).then(data =>
+      expect(data).to.equal(original)
+    );
+  });
+});

--- a/test/src/token/verify-token.test.js
+++ b/test/src/token/verify-token.test.js
@@ -1,0 +1,42 @@
+import { expect } from 'chai';
+import feathers from 'feathers';
+import authentication from '../../../src';
+import verifyToken from '../../../src/token/verify-token';
+
+describe('Token Middleware verifyToken', () => {
+  const app = feathers()
+    .configure(authentication({
+      secret: 'supersecrect'
+    }).use(verifyToken));
+  const auth = app.authentication;
+
+  it('passes through when nothing useful is passed', () => {
+    const dummy = { test: 'me' };
+
+    return auth.authenticate(dummy).then(data =>
+      expect(data).to.equal(dummy)
+    );
+  });
+
+  it('.authenticate verifies a token', () => {
+    const payload = { test: 'data' };
+
+    return auth.createJWT(payload).then(data =>
+      auth.authenticate(data)
+    ).then(data => {
+      expect(data.payload.test).to.equal(payload.test);
+      expect(data.authenticated).to.equal(true);
+    });
+  });
+
+  it('.authenticate verifies a string token', () => {
+    const payload = { test: 'data' };
+
+    return auth.createJWT(payload).then(data =>
+      auth.authenticate(data.token)
+    ).then(data => {
+      expect(data.payload.test).to.equal(payload.test);
+      expect(data.authenticated).to.equal(true);
+    });
+  });
+});


### PR DESCRIPTION
~~This fixes a couple of problems that were occurring in the 1st half of the OAuth flow (up until showing the GitHub auth page)~~  I think the entire OAuth flow should work for every supported provider, now.  

1. The feathers provider plugin name was overwriting the OAuth provider name.
2. If the callbackURL didn't have a leading `/`, Passport would mess it up. (includes tests)

See commit messages for more details.