### PR TITLE
Only set app token if jwt not expired.

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "feathers-commons": "^0.7.5",
     "feathers-errors": "^2.4.0",
     "jsonwebtoken": "^7.1.9",
+    "jwt-decode": "^2.1.0",
     "lodash.intersection": "^4.4.0",
     "lodash.isplainobject": "^4.0.6",
     "lodash.merge": "^4.6.0",

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -21,6 +21,7 @@ export default function(opts = {}) {
 
   return function() {
     const app = this;
+    app.set('authentication', config);
 
     if (!app.get('storage')) {
       const storage = getStorage(config.storage);

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -6,7 +6,8 @@ import {
   logoutSocket,
   getJWT,
   getStorage,
-  clearCookie
+  clearCookie,
+  decodeJWT
 } from './utils';
 
 const defaults = {
@@ -80,6 +81,9 @@ export default function(opts = {}) {
         });
       });
     };
+
+    // Expose the decodeJWT function on the app object.
+    app.decodeJWT = decodeJWT;
 
     // Set our logout method with the correct socket context
     app.logout = function() {

--- a/src/client/utils.js
+++ b/src/client/utils.js
@@ -1,3 +1,5 @@
+import decode from 'jwt-decode';
+
 // Returns a promise that resolves when the socket is connected
 export function connected(app) {
   return new Promise((resolve, reject) => {
@@ -75,13 +77,13 @@ export function clearCookie(name) {
 // Tries the JWT from the given key either from a storage or the cookie
 export function getJWT(tokenKey, cookieKey, storage) {
   return Promise.resolve(storage.getItem(tokenKey)).then(jwt => {
-    const cookieToken = getCookie(cookieKey);
-
-    if (cookieToken) {
-      return cookieToken;
+    let token = jwt || getCookie(cookieKey);
+    if (token) {
+      if (decode(token).exp * 1000 < new Date().getTime()) {
+        token = undefined;
+      }
     }
-
-    return jwt;
+    return token;
   });
 }
 

--- a/src/client/utils.js
+++ b/src/client/utils.js
@@ -74,14 +74,29 @@ export function clearCookie(name) {
   return null;
 }
 
-// Tries the JWT from the given key either from a storage or the cookie
+// Pass a jwt token, get back a payload if it's valid.
+export function decodeJWT(token){
+  let payload;
+  if (token) {
+    let tempPayload = decode(token); 
+    if(payloadIsValid(tempPayload)){
+      payload = tempPayload;
+    }
+  }
+  return payload;
+}
+
+// Pass a decoded payload and it will return a boolean based on if it's still good
+export function payloadIsValid(payload){
+  return payload && payload.exp * 1000 > new Date().getTime() ? true: false; 
+}
+
+// Tries the JWT from the given key either from a storage or the cookie.
 export function getJWT(tokenKey, cookieKey, storage) {
   return Promise.resolve(storage.getItem(tokenKey)).then(jwt => {
     let token = jwt || getCookie(cookieKey);
-    if (token) {
-      if (decode(token).exp * 1000 < new Date().getTime()) {
-        token = undefined;
-      }
+    if (token && !payloadIsValid(decode(token))) {
+      token = undefined;
     }
     return token;
   });

--- a/test/client/index.test.js
+++ b/test/client/index.test.js
@@ -36,6 +36,15 @@ const setupTests = initApp => {
     app = initApp();
   });
 
+  it('config available at app.get("authentication")', () => {
+    expect(app.get('authentication')).to.deep.equal({
+      cookie: 'feathers-jwt',
+      tokenKey: 'feathers-jwt',
+      localEndpoint: '/auth/local',
+      tokenEndpoint: '/auth/token'
+    });
+  });
+
   it('local username password authentication', () => {
     return app.authenticate(options).then(response => {
       expect(response.token).to.not.equal(undefined);

--- a/test/client/index.test.js
+++ b/test/client/index.test.js
@@ -45,6 +45,15 @@ const setupTests = initApp => {
     });
   });
 
+  it('Can decode a passed-in token', () => {
+    return app.authenticate(options).then(response => {
+      let payload = app.decodeJWT(response.token);
+      expect(payload.id).to.equal(0);
+      expect(payload.iss).to.equal('feathers');
+      expect(payload.sub).to.equal('auth');
+    });
+  });
+
   it('local username password authentication', () => {
     return app.authenticate(options).then(response => {
       expect(response.token).to.not.equal(undefined);

--- a/test/client/utils.test.js
+++ b/test/client/utils.test.js
@@ -1,9 +1,9 @@
 import { expect } from 'chai';
-import { getJWT } from '../../src/client/utils';
+import { getJWT, decodeJWT } from '../../src/client/utils';
 
 describe('getJWT', () => {
   it(`get unexpired token from storage`, () => {
-    let token = `eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjEiLCJleHAiOjE0NzYzOTI0ODAsImlhdCI6MjQ3NjM5MjQ4MCwiaXNzIjoiZmVhdGhlcnMifQ.YPR3RjzIZT-LZ2jhySRO2hiyIJAArJFqkWoMfnqCwTc`;
+    let token = `eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjEiLCJleHAiOjI0NzYzOTI0ODAsImlhdCI6MTQ3NjM5MjQ4MCwiaXNzIjoiZmVhdGhlcnMifQ.yU1Jtiw-3ny7auXArUZm10ZP1zQGrzaliM3ky2W6F7c`;
     let storage = {
       getItem(){
         return Promise.resolve(token);
@@ -23,5 +23,25 @@ describe('getJWT', () => {
     getJWT('feathers-jwt', 'feathers-jwt', storage).then(jwt => {
       expect(jwt).to.equal(undefined);
     });
+  });
+});
+
+
+describe('decodeJWT', () => {
+  it('decodes a token properly', () => {
+    let token = `eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MSwiZXhwIjozNDc2MzkyNDgwLCJpYXQiOjE0NzYzOTI0ODAsImlzcyI6ImZlYXRoZXJzIn0.0V6NKoNszBPeIA72xWs2FDW6aPxOnHzEmskulq20uyo`;
+    let payload = decodeJWT(token);
+    expect(payload).to.deep.equal({
+      id: 1,
+      exp: 3476392480,
+      iat: 1476392480,
+      iss: 'feathers'
+    });
+  });
+
+  it('decodes an expired token as undefined', () => {
+    let token = `eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjEiLCJleHAiOjE0NzYzOTI0ODAsImlhdCI6MTQ3NjM5MjQ4MCwiaXNzIjoiZmVhdGhlcnMifQ.6rzpXFqWSmNEotnWo8f-SQ2Ey4rbar3f0pQKNTHdq9A`;
+    let payload = decodeJWT(token);
+    expect(payload).to.equal(undefined);
   });
 });

--- a/test/client/utils.test.js
+++ b/test/client/utils.test.js
@@ -1,0 +1,27 @@
+import { expect } from 'chai';
+import { getJWT } from '../../src/client/utils';
+
+describe('getJWT', () => {
+  it(`get unexpired token from storage`, () => {
+    let token = `eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjEiLCJleHAiOjE0NzYzOTI0ODAsImlhdCI6MjQ3NjM5MjQ4MCwiaXNzIjoiZmVhdGhlcnMifQ.YPR3RjzIZT-LZ2jhySRO2hiyIJAArJFqkWoMfnqCwTc`;
+    let storage = {
+      getItem(){
+        return Promise.resolve(token);
+      }
+    };
+    getJWT('feathers-jwt', 'feathers-jwt', storage).then(jwt => {
+      expect(jwt).to.equal(token);
+    });
+  });
+
+  it(`expired jwt returns undefined`, () => {
+    let storage = {
+      getItem(){
+        return Promise.resolve('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjEiLCJleHAiOjE0NzYzOTI0ODAsImlhdCI6MTQ3NjM5MjQ4MCwiaXNzIjoiZmVhdGhlcnMifQ.6rzpXFqWSmNEotnWo8f-SQ2Ey4rbar3f0pQKNTHdq9A');
+      }
+    };
+    getJWT('feathers-jwt', 'feathers-jwt', storage).then(jwt => {
+      expect(jwt).to.equal(undefined);
+    });
+  });
+});


### PR DESCRIPTION
Modifies the getJWT function to return undefined if the token has expired.  Since we run `getJWT` right away and then set the token with `app.set('token, jwt)`, this gives you a quick way of knowing if the user is (more than likely) authenticated without having to make a request.