### PR TITLE
client: use Authentication class, make `getJWT` and `verifyJWT` async

### DIFF
--- a/src/client/authentication.js
+++ b/src/client/authentication.js
@@ -1,0 +1,101 @@
+import errors from 'feathers-errors';
+import {
+   connected,
+   authenticateSocket,
+   logoutSocket,
+   retrieveJWT,
+   getStorage,
+   clearCookie,
+   verifyJWT
+ } from './utils';
+
+export default class Authentication {
+  constructor (app, options) {
+    this.options = options;
+    this.app = app;
+  }
+
+  authenticate (options = {}) {
+    const app = this.app;
+    let getOptions = Promise.resolve(options);
+
+    // If no type was given let's try to authenticate with a stored JWT
+    if (!options.type) {
+      if (options.token) {
+        options.type = 'token';
+      } else {
+        getOptions = this.getJWT().then(token => {
+          if (!token) {
+            return Promise.reject(new errors.NotAuthenticated(`Could not find stored JWT and no authentication type was given`));
+          }
+          return { type: 'token', token };
+        });
+      }
+    }
+
+    const handleResponse = function (response) {
+      if (response.token) {
+        app.set('token', response.token);
+        app.get('storage').setItem(this.options.tokenKey, response.token);
+      }
+      return Promise.resolve(response);
+    };
+
+    return getOptions.then(options => {
+      let endPoint;
+
+      if (options.type === 'local') {
+        endPoint = this.options.localEndpoint;
+      } else if (options.type === 'token') {
+        endPoint = this.options.tokenEndpoint;
+      } else {
+        throw new Error(`Unsupported authentication 'type': ${options.type}`);
+      }
+
+      return connected(app).then(socket => {
+        // TODO (EK): Handle OAuth logins
+        // If we are using a REST client
+        if (app.rest) {
+          return app.service(endPoint).create(options).then(handleResponse);
+        }
+
+        const method = app.io ? 'emit' : 'send';
+
+        return authenticateSocket(options, socket, method).then(handleResponse);
+      });
+    });
+  }
+
+  getJWT () {
+    const app = this.app;
+    return new Promise((resolve) => {
+      const token = app.get('token');
+      if (token) {
+        return resolve(token);
+      }
+      retrieveJWT(this.options.tokenKey, this.options.cookie, app.get('storage')).then(resolve);
+    });
+  }
+
+  verifyJWT (data) {
+
+  }
+
+  logout () {
+    const app = this.app;
+
+    app.set('token', null);
+    clearCookie(this.options.cookie);
+
+    // remove the token from localStorage
+    return Promise.resolve(app.get('storage').removeItem(this.options.tokenKey)).then(() => {
+      // If using sockets de-authenticate the socket
+      if (app.io || app.primus) {
+        const method = app.io ? 'emit' : 'send';
+        const socket = app.io ? app.io : app.primus;
+
+        return logoutSocket(socket, method);
+      }
+    });
+  }
+}

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -30,7 +30,7 @@ export default function(opts = {}) {
     }
 
     function getJWT () {
-      return new Promise((resolve, reject) => {
+      return new Promise((resolve) => {
         const token = app.get('token');
         if (token) {
           return resolve(token);

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -1,14 +1,5 @@
-import errors from 'feathers-errors';
 import * as hooks from './hooks';
-import {
-  connected,
-  authenticateSocket,
-  logoutSocket,
-  retrieveJWT,
-  getStorage,
-  clearCookie,
-  verifyJWT
-} from './utils';
+import Authentication from './authentication';
 
 const defaults = {
   cookie: 'feathers-jwt',
@@ -17,110 +8,19 @@ const defaults = {
   tokenEndpoint: '/auth/token'
 };
 
-export default function(opts = {}) {
-  const config = Object.assign({}, defaults, opts);
+export default function (opts = {}) {
+  const options = Object.assign({}, defaults, opts);
 
-  return function() {
+  return function () {
     const app = this;
 
-
-    if (!app.get('storage')) {
-      const storage = getStorage(config.storage);
-      app.set('storage', storage);
-    }
-
-    function getJWT () {
-      return new Promise((resolve) => {
-        const token = app.get('token');
-        if (token) {
-          return resolve(token);
-        }
-        retrieveJWT(config.tokenKey, config.cookie, app.get('storage')).then(resolve);
-      });
-    }
-
-    // auto-load any existing JWT from storage
-    getJWT().then(token => {
-      if (token) {
-        app.set('token', token);
-        app.get('storage').setItem(config.tokenKey, token);
-      }
-    });
-
-    app.authenticate = function(options = {}) {
-      let getOptions = Promise.resolve(options);
-
-      // If no type was given let's try to authenticate with a stored JWT
-      if (!options.type) {
-        getOptions = getJWT().then(token => {
-          if (!token) {
-            return Promise.reject(new errors.NotAuthenticated(`Could not find stored JWT and no authentication type was given`));
-          }
-
-          return { type: 'token', token };
-        });
-      }
-
-      const handleResponse = function (response) {
-        if (response.token) {
-          app.set('token', response.token);
-          app.get('storage').setItem(config.tokenKey, response.token);
-        }
-        return Promise.resolve(response);
-      };
-
-      return getOptions.then(options => {
-        let endPoint;
-
-        if (options.type === 'local') {
-          endPoint = config.localEndpoint;
-        } else if (options.type === 'token') {
-          endPoint = config.tokenEndpoint;
-        } else {
-          throw new Error(`Unsupported authentication 'type': ${options.type}`);
-        }
-
-        return connected(app).then(socket => {
-          // TODO (EK): Handle OAuth logins
-          // If we are using a REST client
-          if (app.rest) {
-            return app.service(endPoint).create(options).then(handleResponse);
-          }
-
-          const method = app.io ? 'emit' : 'send';
-
-          return authenticateSocket(options, socket, method).then(handleResponse);
-        });
-      });
-    };
-
-    app.authentication = {
-      options: config,
-      verifyJWT,
-      getJWT
-    };
-
-    // Set our logout method with the correct socket context
-    app.logout = function() {
-      app.set('token', null);
-
-      clearCookie(config.cookie);
-
-      // remove the token from localStorage
-      return Promise.resolve(app.get('storage').removeItem(config.tokenKey)).then(() => {
-        // If using sockets de-authenticate the socket
-        if (app.io || app.primus) {
-          const method = app.io ? 'emit' : 'send';
-          const socket = app.io ? app.io : app.primus;
-
-          return logoutSocket(socket, method);
-        }
-      });
-    };
+    app.authentication = new Authentication(app, options);
+    app.authenticate = app.authentication.authenticate.bind(app.authentication);
+    app.logout = app.authentication.logout.bind(app.authentication);
 
     // Set up hook that adds token and user to params so that
     // it they can be accessed by client side hooks and services
-    app.mixins.push(function(service) {
+    app.mixins.push(function (service) {
       if (typeof service.before !== 'function' || typeof service.after !== 'function') {
         throw new Error(`It looks like feathers-hooks isn't configured. It is required before running feathers-authentication.`);
       }
@@ -130,8 +30,8 @@ export default function(opts = {}) {
 
     // Set up hook that adds authorization header for REST provider
     if (app.rest) {
-      app.mixins.push(function(service) {
-        service.before(hooks.populateHeader(config));
+      app.mixins.push(function (service) {
+        service.before(hooks.populateHeader(options));
       });
     }
   };

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -41,8 +41,10 @@ export default function(opts = {}) {
 
     // auto-load any existing JWT from storage
     getJWT().then(token => {
-      app.set('token', token);
-      app.get('storage').setItem(config.tokenKey, token);
+      if (token) {
+        app.set('token', token);
+        app.get('storage').setItem(config.tokenKey, token);
+      }
     });
 
     app.authenticate = function(options = {}) {
@@ -60,10 +62,11 @@ export default function(opts = {}) {
       }
 
       const handleResponse = function (response) {
-        app.set('token', response.token);
-
-        return Promise.resolve(app.get('storage').setItem(config.tokenKey, response.token))
-          .then(() => response);
+        if (response.token) {
+          app.set('token', response.token);
+          app.get('storage').setItem(config.tokenKey, response.token);
+        }
+        return Promise.resolve(response);
       };
 
       return getOptions.then(options => {

--- a/src/client/utils.js
+++ b/src/client/utils.js
@@ -75,29 +75,33 @@ export function clearCookie(name) {
 }
 
 // Pass a jwt token, get back a payload if it's valid.
-export function verifyJWT(data){
-  const token = typeof data === 'string' ? data : data.token;
-  let payload;
-  if (token) {
-    try {
-      let tempPayload = decode(token); 
-      if(payloadIsValid(tempPayload)){
-        payload = tempPayload;
+export function verifyJWT (data) {
+  return new Promise((resolve, reject) => {
+    const token = typeof data === 'string' ? data : data.token;
+    if (token) {
+      try {
+        let payload = decode(token);
+        if (payloadIsValid(payload)) {
+          resolve(payload);
+        } else {
+          reject(new Error('Invalid token: expired'));
+        }
+      } catch (error) {
+        reject(new Error('Cannot decode malformed token.'));
       }
-    } catch (error) {
-      console.error('Cannot decode malformed token.');   
+    } else {
+      reject(new Error('No token provided to verifyJWT'));
     }
-  }
-  return payload;
+  });
 }
 
 // Pass a decoded payload and it will return a boolean based on if it hasn't expired.
-export function payloadIsValid(payload){
-  return payload && payload.exp * 1000 > new Date().getTime() ? true: false; 
+export function payloadIsValid (payload) {
+  return payload && payload.exp * 1000 > new Date().getTime();
 }
 
 // Tries the JWT from the given key either from a storage or the cookie.
-export function getJWT(tokenKey, cookieKey, storage) {
+export function retrieveJWT (tokenKey, cookieKey, storage) {
   return Promise.resolve(storage.getItem(tokenKey)).then(jwt => {
     let token = jwt || getCookie(cookieKey);
     if (token && token !== 'null' && !payloadIsValid(decode(token))) {
@@ -108,7 +112,7 @@ export function getJWT(tokenKey, cookieKey, storage) {
 }
 
 // Returns a storage implementation
-export function getStorage(storage) {
+export function getStorage (storage) {
   if (storage) {
     return storage;
   }

--- a/test/client/index.test.js
+++ b/test/client/index.test.js
@@ -46,19 +46,21 @@ const setupTests = initApp => {
     });
   });
 
-  it('can use getJWT to get the token', () => {
+  it('can use app.authentication.getJWT() to get the token', () => {
     return app.authenticate(options).then(response => {
-      let token = app.authentication.getJWT();
-      expect(token).to.equal(response.token);
+      app.authentication.getJWT().then(token => {
+        expect(token).to.equal(response.token);
+      });
     });
   });
 
-  it('can decode a passed-in token', () => {
+  it('can decode a token with app.authentication.verifyToken()', () => {
     return app.authenticate(options).then(response => {
-      let payload = app.authentication.verifyJWT(response);
-      expect(payload.id).to.equal(0);
-      expect(payload.iss).to.equal('feathers');
-      expect(payload.sub).to.equal('auth');
+      return app.authentication.verifyJWT(response).then(payload => {
+        expect(payload.id).to.equal(0);
+        expect(payload.iss).to.equal('feathers');
+        expect(payload.sub).to.equal('auth');
+      });
     });
   });
 

--- a/test/client/utils.test.js
+++ b/test/client/utils.test.js
@@ -1,28 +1,28 @@
 import { expect } from 'chai';
-import { getJWT, verifyJWT } from '../../src/client/utils';
+import { retrieveJWT, verifyJWT } from '../../src/client/utils';
 
 const validToken = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MSwiZXhwIjozNDc2MzkyNDgwLCJpYXQiOjE0NzYzOTI0ODAsImlzcyI6ImZlYXRoZXJzIn0.0V6NKoNszBPeIA72xWs2FDW6aPxOnHzEmskulq20uyo';
 const expiredToken = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjEiLCJleHAiOjE0NzYzOTI0ODAsImlhdCI6MTQ3NjM5MjQ4MCwiaXNzIjoiZmVhdGhlcnMifQ.6rzpXFqWSmNEotnWo8f-SQ2Ey4rbar3f0pQKNTHdq9A';
 
-describe('getJWT', () => {
+describe('retrieveJWT', () => {
   it(`get unexpired token from storage`, () => {
     let storage = {
-      getItem(){
+      getItem () {
         return Promise.resolve(validToken);
       }
     };
-    getJWT('feathers-jwt', 'feathers-jwt', storage).then(jwt => {
+    retrieveJWT('feathers-jwt', 'feathers-jwt', storage).then(jwt => {
       expect(jwt).to.equal(validToken);
     });
   });
 
   it(`expired jwt returns undefined`, () => {
     let storage = {
-      getItem(){
+      getItem () {
         return Promise.resolve(expiredToken);
       }
     };
-    getJWT('feathers-jwt', 'feathers-jwt', storage).then(jwt => {
+    retrieveJWT('feathers-jwt', 'feathers-jwt', storage).then(jwt => {
       expect(jwt).to.equal(undefined);
     });
   });
@@ -31,36 +31,40 @@ describe('getJWT', () => {
 
 describe('verifyJWT', () => {
   it('decodes a token string properly', () => {
-    let payload = verifyJWT(validToken);
-    expect(payload).to.deep.equal({
-      id: 1,
-      exp: 3476392480,
-      iat: 1476392480,
-      iss: 'feathers'
+    return verifyJWT(validToken).then(payload => {
+      expect(payload).to.deep.equal({
+        id: 1,
+        exp: 3476392480,
+        iat: 1476392480,
+        iss: 'feathers'
+      });
     });
   });
 
   it('decodes a token from an object properly', () => {
     let data = {
-      token: validToken 
+      token: validToken
     };
-    let payload = verifyJWT(data);
-    expect(payload).to.deep.equal({
-      id: 1,
-      exp: 3476392480,
-      iat: 1476392480,
-      iss: 'feathers'
+    return verifyJWT(data).then(payload => {
+      expect(payload).to.deep.equal({
+        id: 1,
+        exp: 3476392480,
+        iat: 1476392480,
+        iss: 'feathers'
+      });
     });
   });
 
   it('gracefully handles an invalid token', () => {
     let token = `lily`;
-    let payload = verifyJWT(token);
-    expect(payload).to.equal(undefined);
+    return verifyJWT(token).catch(error => {
+      expect(error instanceof Error).to.equal(true);
+    });
   });
 
-  it('decodes an expired token as undefined', () => {
-    let payload = verifyJWT(expiredToken);
-    expect(payload).to.equal(undefined);
+  it('throws an error with an expired token', () => {
+    return verifyJWT(expiredToken).catch(error => {
+      expect(error instanceof Error).to.equal(true);
+    });
   });
 });


### PR DESCRIPTION
This modifies both `getJWT` and `verifyJWT` to return promises.  `getJWT` has also been updated to check the store for the token again to support environments that don’t load cookies immediately.

Also renames the `getJWT` util function to `retrieveJWT` to avoid ambiguity.