### PR TITLE
Socket.io authentication tests and login logout event

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "debug": "^2.2.0",
     "feathers-commons": "^0.7.5",
     "feathers-errors": "^2.4.0",
+    "feathers-socket-commons": "^2.3.1",
     "jsonwebtoken": "^7.1.9",
     "lodash.merge": "^4.6.0",
     "lodash.omit": "^4.5.0",

--- a/src/base.js
+++ b/src/base.js
@@ -5,7 +5,7 @@ import middlewares from './middleware/authentication';
 const debug = Debug('feathers-authentication:authentication:base');
 
 // A basic Authentication class that allows to create and verify JWTs
-// and also run through
+// and also run through a token authentication chain
 export default class Authentication {
   constructor(app, options) {
     this.options = options;
@@ -18,7 +18,7 @@ export default class Authentication {
     this._middleware.isInitial = true;
   }
 
-  // Register on or more handlers for the JWT verification chain
+  // Register one or more handlers for the JWT verification chain
   use(... middleware) {
     // Reset the default middleware chain
     if(this._middleware.isInitial) {

--- a/src/base.js
+++ b/src/base.js
@@ -4,6 +4,8 @@ import middlewares from './middleware/authentication';
 
 const debug = Debug('feathers-authentication:authentication:base');
 
+// A basic Authentication class that allows to create and verify JWTs
+// and also run through
 export default class Authentication {
   constructor(app, options) {
     this.options = options;
@@ -16,6 +18,7 @@ export default class Authentication {
     this._middleware.isInitial = true;
   }
 
+  // Register on or more handlers for the JWT verification chain
   use(... middleware) {
     // Reset the default middleware chain
     if(this._middleware.isInitial) {
@@ -31,6 +34,7 @@ export default class Authentication {
     return this;
   }
 
+  // Run the JWT verification chain against data
   authenticate(data) {
     let promise = Promise.resolve(data);
 
@@ -46,6 +50,8 @@ export default class Authentication {
     return promise;
   }
 
+  // Returns a { token } object either from a string,
+  // an HTTP request object or another object with a `.token` property
   getJWT(data) {
     const { header } = this.options;
 
@@ -70,7 +76,7 @@ export default class Authentication {
         debug('Token found in header', token);
       }
 
-      return Promise.resolve({ token, req });
+      return Promise.resolve({ token });
     }
     else if (typeof data === 'object' && data.token) {
       return Promise.resolve({ token: data.token });

--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,6 @@ import { socketioHandler, primusHandler } from './middleware/socket';
 import getOptions from './options';
 import Authentication from './base';
 import service from './service';
-// import tokenAuth from './token-auth';
 
 const debug = Debug('feathers-authentication:index');
 
@@ -32,14 +31,12 @@ export default function init(config = {}) {
       options.cookie.secure = false;
     }
 
-    debug('Initializing base Authentication class');
+    debug('Setting up Authentication class and Express middleware');
+
     app.authentication = new Authentication(app, options);
-
-    debug('registering Express authentication middleware');
+    app.authenticate = app.authentication.authenticate.bind(app.authenticate);
     app.use(express.getJWT(options));
-
     app.configure(service(options));
-    // app.configure(tokenAuth(options));
 
     app.setup = function() {
       let result = _super.apply(this, arguments);

--- a/src/middleware/authentication/populate-user.js
+++ b/src/middleware/authentication/populate-user.js
@@ -3,6 +3,7 @@ import Debug from 'debug';
 const debug = Debug('feathers-authentication:token:populate-user');
 
 export default function(options) {
+  const app = this;
   const { user } = options;
 
   if (!user.service) {
@@ -14,7 +15,6 @@ export default function(options) {
   }
 
   return function populateUser(data) {
-    const app = this;
     const service = typeof user.service === 'string' ? app.service(user.service) : user.service;
     const { payloadField } = user;
 

--- a/src/middleware/authentication/verify-key.js
+++ b/src/middleware/authentication/verify-key.js
@@ -4,7 +4,7 @@ const debug = Debug('feathers-authentication:token:verifyKey');
 
 export default function(options) {
   return function verifyKey(data) {
-    if (data && data.token) {
+    if (data && data[options.keyfield]) {
       const app = this;
       const key = data[options.keyfield];
 

--- a/src/middleware/socket/index.js
+++ b/src/middleware/socket/index.js
@@ -24,7 +24,7 @@ export function primusHandler(app, options = {}) {
   const providerSettings = {
     provider: 'primus',
     emit: 'send',
-    disconnect: 'disconnection',
+    disconnect: 'end',
     feathersParams(socket) {
       return socket.request.feathers;
     }

--- a/src/service.js
+++ b/src/service.js
@@ -21,10 +21,6 @@ class Service {
   }
 
   remove(id, params) {
-    if (params.provider && !params.authentication) {
-      return Promise.reject(new Error(`External ${params.provider} requests need to run through an authentication provider`));
-    }
-
     const token = id !== null ? id : params.token;
 
     this.emit('logout', { token });

--- a/test/base.test.js
+++ b/test/base.test.js
@@ -95,7 +95,6 @@ describe('Feathers Authentication Base Class', () => {
         };
 
         return auth.getJWT(mockRequest).then(data => {
-          expect(data.req).to.equal(mockRequest);
           expect(data.token).to.equal('sometoken');
         });
       });
@@ -108,7 +107,6 @@ describe('Feathers Authentication Base Class', () => {
         };
 
         return auth.getJWT(mockRequest).then(data => {
-          expect(data.req).to.equal(mockRequest);
           expect(data.token).to.equal('sometoken');
         });
       });

--- a/test/fixtures/server.js
+++ b/test/fixtures/server.js
@@ -45,6 +45,12 @@ export default function(settings, useSocketio = true) {
           userId: 0,
           authentication: 'test-auth'
         };
+      } else if(hook.data.login === 'testing-fail') {
+        hook.params.authentication = 'test-auth';
+
+        hook.data.payload = {
+          authentication: 'test-auth'
+        };
       }
     }
   });

--- a/test/integration/primus.test.js
+++ b/test/integration/primus.test.js
@@ -30,16 +30,9 @@ describe('Primus authentication', function() {
 
   it('returns not authenticated error for protected endpoint', done => {
     primus.send('todos::get', 'laundry', e => {
-      delete e.stack;
-      delete e.type;
+      expect(e.name).to.equal('NotAuthenticated');
+      expect(e.code).to.equal(401);
 
-      expect(e).to.deep.equal({
-        name: 'NotAuthenticated',
-        message: 'You are not authenticated.',
-        code: 401,
-        className: 'not-authenticated',
-        errors: {}
-      });
       done();
     });
   });
@@ -150,16 +143,9 @@ describe('Primus authentication', function() {
   it('no access allowed after logout', done => {
     app.once('logout', function() {
       primus.send('todos::get', 'laundry', e => {
-        delete e.stack;
-        delete e.type;
+        expect(e.name).to.equal('NotAuthenticated');
+        expect(e.code).to.equal(401);
 
-        expect(e).to.deep.equal({
-          name: 'NotAuthenticated',
-          message: 'You are not authenticated.',
-          code: 401,
-          className: 'not-authenticated',
-          errors: {}
-        });
         done();
       });
     });

--- a/test/integration/socketio.test.js
+++ b/test/integration/socketio.test.js
@@ -27,16 +27,9 @@ describe('Socket.io authentication', function() {
 
   it('returns not authenticated error for protected endpoint', done => {
     socket.emit('todos::get', 'laundry', e => {
-      delete e.stack;
-      delete e.type;
+      expect(e.name).to.equal('NotAuthenticated');
+      expect(e.code).to.equal(401);
 
-      expect(e).to.deep.equal({
-        name: 'NotAuthenticated',
-        message: 'You are not authenticated.',
-        code: 401,
-        className: 'not-authenticated',
-        errors: {}
-      });
       done();
     });
   });
@@ -147,16 +140,9 @@ describe('Socket.io authentication', function() {
   it('no access allowed after logout', done => {
     app.once('logout', function() {
       socket.emit('todos::get', 'laundry', e => {
-        delete e.stack;
-        delete e.type;
+        expect(e.name).to.equal('NotAuthenticated');
+        expect(e.code).to.equal(401);
 
-        expect(e).to.deep.equal({
-          name: 'NotAuthenticated',
-          message: 'You are not authenticated.',
-          code: 401,
-          className: 'not-authenticated',
-          errors: {}
-        });
         done();
       });
     });


### PR DESCRIPTION
This pull request adds further tests for Socket.io authentication and implements login and logout events for it. Now it is possible to do this:

```js
app.on('login', function(authResult, info) {
  // authResult -> result from app.authentication.authenticate
  // info -> { socket, connection, provider }
});

app.on('logout', function(authResult, info) {
  // authResult -> result from app.authentication.authenticate
  // info -> { socket, connection, provider }
});
```

Getting the `info` object is useful so that we can e.g. keep the connection up to date with the latest user information (or let people do other things outside of the abstracted service flow).