### PR TITLE
Implement login and logout events for REST authentication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ lib/
 coverage/
 data.db
 _backup/
+yarn.lock

--- a/src/middleware/express/events.js
+++ b/src/middleware/express/events.js
@@ -1,0 +1,37 @@
+import Debug from 'debug';
+
+const debug = Debug('feathers-authentication:express:events');
+
+export default function() {
+  return function(req, res, next) {
+    const method = res.hook && res.hook.method;
+
+    let event = null;
+
+    if(method === 'remove') {
+      event = 'logout';
+    } else if(method === 'create') {
+      event = 'login';
+    }
+
+    if(res.data && res.data.token && event) {
+      const { app } = req;
+
+      app.authentication.authenticate(res.data)
+        .then(result => {
+          debug(`Sending '${event}' event for REST provider token is`,
+            res.data.token
+          );
+
+          app.emit(event, result, {
+            provider: 'rest',
+            req, res
+          });
+
+          next();
+        }).catch(next);
+    } else {
+      next();
+    }
+  };
+}

--- a/src/middleware/express/get-jwt.js
+++ b/src/middleware/express/get-jwt.js
@@ -1,6 +1,6 @@
 import Debug from 'debug';
 
-const debug = Debug('feathers-authentication:middleware:get-jwt');
+const debug = Debug('feathers-authentication:express:get-jwt');
 
 export default function () {
   return function getJWT(req, res, next) {

--- a/src/middleware/express/index.js
+++ b/src/middleware/express/index.js
@@ -2,10 +2,12 @@ import setCookie from './set-cookie';
 import successRedirect from './success-redirect';
 import isAuthenticated from './is-authenticated';
 import getJWT from './get-jwt';
+import events from './events';
 
 export default {
   getJWT,
   isAuthenticated,
   setCookie,
-  successRedirect
+  successRedirect,
+  events
 };

--- a/src/service.js
+++ b/src/service.js
@@ -1,5 +1,5 @@
 import Debug from 'debug';
-import { successRedirect, setCookie } from './middleware/express';
+import { successRedirect, setCookie, events } from './middleware/express';
 
 const debug = Debug('feathers-authentication:authentication:service');
 
@@ -40,7 +40,9 @@ export default function init(options){
 
     debug('Configuring authentication service at path', path);
 
-    app.use(path, new Service(app, options), setCookie(options), successRedirect(options));
+    app.use(path, new Service(app, options),
+      events(options), setCookie(options), successRedirect(options)
+    );
   };
 }
 

--- a/test/integration/rest.test.js
+++ b/test/integration/rest.test.js
@@ -78,4 +78,52 @@ describe('REST authentication', function() {
       });
     });
   });
+
+  it('app `login` event', done => {
+    app.once('login', function(auth, info) {
+      expect(auth.token).to.exist;
+      expect(auth.user).to.deep.equal({ id: 0, name: 'Tester' });
+
+      expect(info.provider).to.equal('rest');
+      expect(info.req).to.exist;
+      expect(info.res).to.exist;
+
+      done();
+    });
+
+    request({
+      url: '/authentication',
+      method: 'POST',
+      body: {
+        login: 'testing'
+      }
+    });
+  });
+
+  it('app `logout` event', done => {
+    app.once('logout', function(auth, info) {
+      expect(auth.token).to.exist;
+      expect(auth.user).to.deep.equal({ id: 0, name: 'Tester' });
+
+      expect(info.provider).to.equal('rest');
+      expect(info.req).to.exist;
+      expect(info.res).to.exist;
+
+      done();
+    });
+
+    request({
+      url: '/authentication',
+      method: 'POST',
+      body: {
+        login: 'testing'
+      }
+    }).then(login => request({
+      url: `/authentication`,
+      method: 'DELETE',
+      headers: {
+        'Authorization': login.token
+      }
+    }));
+  });
 });


### PR DESCRIPTION
This adds `login` and `logout` events for RESTful authentication:

```js
app.on('login', function(auth, info) {
  // auth.token -> token
  // auth.user -> user (if applicable)

  // info.provider -> 'REST'
  // info.req -> HTTP request
  // info.res -> HTTP response
});
```