### PR TITLE
restrictToOwner -Fix check for methodNotAllowed

### DIFF
--- a/src/hooks/restrict-to-owner.js
+++ b/src/hooks/restrict-to-owner.js
@@ -13,7 +13,7 @@ export default function(options = {}){
     }
     
     // Check hook is being called on an allowable method
-    if (!hook.method === 'get' || !hook.method === 'update' || !hook.method === 'patch' || !hook.method === 'remove') {
+    if (!(hook.method === 'get' || hook.method === 'update' || hook.method === 'patch' || hook.method === 'remove')) { {
       throw new errors.MethodNotAllowed(`The 'restrictToOwner' hook should only be used on the 'get', 'update', 'patch' and 'remove' service methods.`);
     }
 

--- a/src/hooks/restrict-to-owner.js
+++ b/src/hooks/restrict-to-owner.js
@@ -11,8 +11,9 @@ export default function(options = {}){
     if (hook.type !== 'before') {
       throw new Error(`The 'restrictToOwner' hook should only be used as a 'before' hook.`);
     }
-
-    if (!hook.id) {
+    
+    // Check hook is being called on an allowable method
+    if (!hook.method === 'get' || !hook.method === 'update' || !hook.method === 'patch' || !hook.method === 'remove') {
       throw new errors.MethodNotAllowed(`The 'restrictToOwner' hook should only be used on the 'get', 'update', 'patch' and 'remove' service methods.`);
     }
 


### PR DESCRIPTION
Hi!

methodNotAllowed was being checked as "if (!hook.id)", leading to erroneous or misleading error messages.
Changed to check against hook.method 

This also fixes #319