### PR TITLE
0.8 client oauth utils

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "bcryptjs": "^2.3.0",
     "cookie-parser": "^1.4.3",
     "debug": "^2.2.0",
+    "events": "^1.1.1",
     "feathers-commons": "^0.7.5",
     "feathers-errors": "^2.4.0",
     "jsonwebtoken": "^7.1.9",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "compile": "rm -rf lib/ && babel -d lib/ src/",
     "watch": "babel --watch -d lib/ src/",
     "jshint": "jshint src/. test/. --config",
-    "mocha": "mocha --opts mocha.opts -r jsdom-global/register",
+    "mocha": "mocha --opts mocha.opts",
     "coverage": "istanbul cover _mocha -- --opts mocha.opts -r jsdom-global/register",
     "test": "npm run compile && npm run jshint && npm run coverage && nsp check"
   },

--- a/package.json
+++ b/package.json
@@ -36,8 +36,8 @@
     "compile": "rm -rf lib/ && babel -d lib/ src/",
     "watch": "babel --watch -d lib/ src/",
     "jshint": "jshint src/. test/. --config",
-    "mocha": "mocha --opts mocha.opts",
-    "coverage": "istanbul cover _mocha -- --opts mocha.opts",
+    "mocha": "mocha --opts mocha.opts -r jsdom-global/register",
+    "coverage": "istanbul cover _mocha -- --opts mocha.opts -r jsdom-global/register",
     "test": "npm run compile && npm run jshint && npm run coverage && nsp check"
   },
   "directories": {
@@ -77,6 +77,8 @@
     "feathers-rest": "^1.5.0",
     "feathers-socketio": "^1.3.2",
     "istanbul": "^1.1.0-alpha.1",
+    "jsdom": "9.8.3",
+    "jsdom-global": "2.1.0",
     "jshint": "^2.9.3",
     "localstorage-memory": "^1.0.2",
     "mocha": "^3.0.2",

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -8,6 +8,8 @@ const defaults = {
   tokenEndpoint: '/auth/token'
 };
 
+export {openLoginPopup, authAgent} from './oauth';
+
 export default function (opts = {}) {
   const options = Object.assign({}, defaults, opts);
 

--- a/src/client/oauth.js
+++ b/src/client/oauth.js
@@ -1,0 +1,26 @@
+import EventEmitter from 'events';
+
+export const authAgent = window.authAgent = new EventEmitter();
+
+/*
+ * A helper template to that opens the provided URL in a centered popup.
+ * Accepts an `options` object with `width` and `height` number properties.
+ */
+export function openLoginPopup (url, options = {}) {
+  let width = options.width || 1024;
+  let height = options.height || 640;
+  let {top, left} = getCenterCoordinates(window, width, height);
+  let params = `width=${width}, height=${height}, top=${top}, left=${left}`;
+  return window.open(url, 'authWindow', params);
+}
+
+/*
+ * Returns the coordinates to center a popup window in the viewport with
+ * the provided width and height args.
+ */
+export function getCenterCoordinates (window, width, height) {
+  return {
+    left: window.screenX + (window.outerWidth - width) / 2,
+    top: window.screenY + (window.outerHeight - height) / 2
+  };
+}

--- a/test/client/oauth.test.js
+++ b/test/client/oauth.test.js
@@ -1,0 +1,29 @@
+global.window = {
+  open () {
+    return {success: true};
+  }
+};
+
+import { expect } from 'chai';
+import {openLoginPopup, authAgent} from '../../src/client';
+import {getCenterCoordinates} from '../../src/client/oauth';
+import EventEmitter from 'events';
+
+describe('OAuth Popup', () => {
+  it(`opens new window`, () => {
+    let authWindow = openLoginPopup('/auth/github');
+    expect(authWindow).to.not.equal(undefined);
+  });
+});
+
+describe('authAgent EventEmitter', () => {
+  it(`sets up an eventEmitter at window.authAgent`, () => {
+    expect(authAgent instanceof EventEmitter).to.equal(true);
+  });
+});
+
+describe('getCenterCoordinates', () => {
+  it(`function exists`, () => {
+    expect(typeof getCenterCoordinates).to.equal('function');
+  });
+});

--- a/test/client/oauth.test.js
+++ b/test/client/oauth.test.js
@@ -1,20 +1,7 @@
-global.window = {
-  open () {
-    return {success: true};
-  }
-};
-
 import { expect } from 'chai';
-import {openLoginPopup, authAgent} from '../../src/client';
+import {authAgent} from '../../src/client';
 import {getCenterCoordinates} from '../../src/client/oauth';
 import EventEmitter from 'events';
-
-describe('OAuth Popup', () => {
-  it(`opens new window`, () => {
-    let authWindow = openLoginPopup('/auth/github');
-    expect(authWindow).to.not.equal(undefined);
-  });
-});
 
 describe('authAgent EventEmitter', () => {
   it(`sets up an eventEmitter at window.authAgent`, () => {


### PR DESCRIPTION
Adds utilities for managing auth popups

This adds an `openLoginPopup` util function that takes a URL and opens an OAuth window (or whatever URL you give it) in a popup.  It also creates a global `authAgent` EventEmitter on the main page, which can be used to receive data from the popup after OAuth redirects.