### PR TITLE
Authenticate with custom endpoint over websockets

### DIFF
--- a/src/middleware/sockets.js
+++ b/src/middleware/sockets.js
@@ -46,7 +46,10 @@ function setupSocketHandler(feathersParams, provider, emit, app, options) {
 
         params.req.body = data;
 
-        app.service(options.localEndpoint).create(data, params).then(response => {
+        // If an endPoint was provided in the request, use it.
+        const endPoint = data.endpoint ? data.endpoint : options.localEndpoint;
+
+        app.service(endPoint).create(data, params).then(response => {
           feathersParams(socket).token = response.token;
           feathersParams(socket).user = response.data;
           socket[emit]('authenticated', response);


### PR DESCRIPTION
Same motivation as #278, but using websockets instead.  It was confusing that I could manually supply an endpoint using rest and it would be ignored if going over sockets.

This PR aims to do for websockets what #278 did for the rest provider, i.e., to allow the client to `authenticate` with a custom endpoint such as `auth/facebook`.