### PR TITLE
adding a value for checking against oauth

### DIFF
--- a/src/express/authenticate.js
+++ b/src/express/authenticate.js
@@ -28,7 +28,7 @@ export default function authenticate (strategy, options = {}) {
         Object.assign(req, { authenticated: true }, result.data);
         Object.assign(req.feathers, { authenticated: true }, result.data);
 
-        if (options.successRedirect) {
+        if (options.successRedirect && !options.__oauth) {
           debug(`Redirecting to ${options.successRedirect}`);
           res.status(302);
           return res.redirect(options.successRedirect);
@@ -38,7 +38,7 @@ export default function authenticate (strategy, options = {}) {
       }
 
       if (result.fail) {
-        if (options.failureRedirect) {
+        if (options.failureRedirect && !options.__oauth) {
           debug(`Redirecting to ${options.failureRedirect}`);
           res.status(302);
           return res.redirect(options.failureRedirect);


### PR DESCRIPTION
### Summary

This ensures that the app isn't redirected early in the case of oauth and still runs through the other middleware registered with the oauth plugins.

### Other Information
