### PR TITLE
add optional option to auth hook

### DIFF
--- a/src/hooks/authenticate.js
+++ b/src/hooks/authenticate.js
@@ -38,7 +38,7 @@ export default function authenticate (strategy, options = {}) {
     debug(`Attempting to authenticate using ${strategy} strategy with options`, options);
 
     return app.authenticate(strategy, options)(request).then((result = {}) => {
-      if (result.fail) {
+      if (result.fail && !options.optional) {
         // TODO (EK): Reject with something...
         // You get back result.challenge and result.status
         if (options.failureRedirect) {


### PR DESCRIPTION
It's really great that the new authentication populates the user. However, often-times it's nice to know if the user is authenticated, and have access to that data, but the authentication itself is not required. What do you guys think of a simple optional boolean exposed when using the hook?

As an example, we use the presence of an authenticated user to filter the properties returned to the client in find and get requests, but it is not required that the request be authenticated.

```js
exports.before = {
  all: [],
  find: [
    auth.hooks.authenticate(['local', 'jwt'], {optional: true}),
  ],
  get: [
    auth.hooks.authenticate(['local', 'jwt'], {optional: true}),
  ],
  create: [],
  update: [
    auth.hooks.authenticate(['local', 'jwt']),
  ],
  patch: [
    auth.hooks.authenticate(['local', 'jwt']),
  ],
  remove: [
    auth.hooks.authenticate(['local', 'jwt']),
  ],
};
```