### PR TITLE
Prevent setCookie from mutating authOptions

### DIFF
--- a/src/express/set-cookie.js
+++ b/src/express/set-cookie.js
@@ -13,7 +13,8 @@ export default function setCookie (authOptions = {}) {
 
   return function (req, res, next) {
     const app = req.app;
-    const options = authOptions.cookie || {};
+    // Prevent mutating authOptions object
+    const options = Object.assign({}, authOptions.cookie);
 
     debug('Running setCookie middleware with options:', options);
 

--- a/test/express/set-cookie.test.js
+++ b/test/express/set-cookie.test.js
@@ -137,6 +137,14 @@ describe('express:setCookie', () => {
       });
     });
 
+    it('does not mutate given option object', done => {
+      setCookie(options)(req, res, () => {
+        expect(res.cookie.getCall(0).args[2].expires).to.be.defined;
+        expect(options.expires).to.be.undefined;
+        done();
+      });
+    });
+
     it('calls next', next => {
       setCookie(options)(req, res, next);
     });


### PR DESCRIPTION
setCookie is mutating `authOptions`, setting a constant value for `expires` attribute which is then re-used on every further `setCookie` calls. 

After a while, cookies are sent already-expired...this PR should fix it (is it a proper way to do it ?).

Thanks for this awesome framework !