### PR TITLE
Add client.js back for consistency

### DIFF
--- a/client.js
+++ b/client.js
@@ -1,0 +1,1 @@
+module.exports = require('feathers-authentication-client');

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
   },
   "dependencies": {
     "debug": "^2.2.0",
+    "feathers-authentication-client": "^0.1.10",
     "feathers-commons": "^0.8.4",
     "feathers-errors": "^2.4.0",
     "feathers-socket-commons": "^2.3.1",


### PR DESCRIPTION
Currently all client side modules are provided as `feathers-<name>/client` (e.g. `feathers/client`, `feathers-rest/client` etc.). Adding back a `feathers-authentication/client` which re-exports `feathers-authentication-client` in order to be consistent until we split everything into their own client modules (`feathers-rest-client`, `feathers-socketio-client` etc.) in the next version (see https://github.com/feathersjs/feathers-client/issues/137).