### PR TITLE
Windows compatible version of the original compile comand with public folder support.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,7 @@ _backup/
 
 # Yarn lockfile
 yarn.lock
+
+# local options/storage for JetBrains WebStorm and Visual Studio 2017 IDE folder
+.idea/
+.vs/

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "release:major": "npm version major && npm publish",
     "release:pre": "npm publish --tag next",
     "changelog": "github_changelog_generator && git add CHANGELOG.md && git commit -am \"Updating changelog\"",
-    "compile": "rimraf lib/ && babel -d lib/ src/ && babel -Dd lib/public src/public",
+    "compile": "rimraf lib/ && babel -d lib/ src/",
     "watch": "babel --watch -d lib/ src/",
     "lint": "semistandard --fix",
     "mocha": "mocha --opts mocha.opts",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "release:major": "npm version major && npm publish",
     "release:pre": "npm publish --tag next",
     "changelog": "github_changelog_generator && git add CHANGELOG.md && git commit -am \"Updating changelog\"",
-    "compile": "rimraf -rf lib/ && babel -d lib/ src/",
+    "compile": "rimraf lib/ && babel -d lib/ src/ && babel -Dd lib/public src/public",
     "watch": "babel --watch -d lib/ src/",
     "lint": "semistandard --fix",
     "mocha": "mocha --opts mocha.opts",


### PR DESCRIPTION
- In the `legacy` branch, the `npm run compile` command was:
```
rm -rf lib/ && babel -d lib/ src/ && mkdir lib/public/ && cp src/public/* lib/public/
```
But that wasn't windows compatible. Two problems: forward slashes on the mkdir and cp commands cause parameter errors, and missing the `cp` command on Windows.  Although `rimraf` takes care of the first half, I suspect the `public` copy was lost because a cross-platform recursive mkdir+cp is hard to find. But it turns out that `babel -D` handles that.
- Also fixed the extra `-rf` that should not be used with `rimraf`.
- Also added `.idea` and `.vs` Windows IDE user folders to `.gitignore` file.