### PR TITLE
add option to allowUnauthenticated

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,7 @@ _backup/
 
 # Yarn lockfile
 yarn.lock
+
+# local options/storage for JetBrains WebStorm and Visual Studio 2017 IDE folder
+.idea/
+.vs/

--- a/.gitignore
+++ b/.gitignore
@@ -27,7 +27,6 @@ node_modules
 # Users Environment Variables
 .lock-wscript
 
-lib/
 coverage/
 data.db
 _backup/

--- a/lib/express/authenticate.js
+++ b/lib/express/authenticate.js
@@ -1,0 +1,91 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.default = authenticate;
+
+var _feathersErrors = require('feathers-errors');
+
+var _feathersErrors2 = _interopRequireDefault(_feathersErrors);
+
+var _debug = require('debug');
+
+var _debug2 = _interopRequireDefault(_debug);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+var debug = (0, _debug2.default)('feathers-authentication:express:authenticate');
+
+function authenticate(strategy) {
+  var options = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+
+  // TODO (EK): Support arrays of strategies
+
+  if (!strategy) {
+    throw new Error('The \'authenticate\' hook requires one of your registered passport strategies.');
+  }
+
+  return function (req, res, next) {
+    // If we are already authenticated skip
+    if (req.authenticated) {
+      return next();
+    }
+
+    // if (!req.app.passport._strategy(strategy)) {
+    //   return next(new Error(`Your '${strategy}' authentication strategy is not registered with passport.`));
+    // }
+    // TODO (EK): Can we do something in here to get away
+    // from express-session for OAuth1?
+    // TODO (EK): Handle chaining multiple strategies
+    req.app.authenticate(strategy, options)(req).then(function () {
+      var result = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
+
+      // TODO (EK): Support passport failureFlash
+      // TODO (EK): Support passport successFlash
+      if (result.success) {
+        Object.assign(req, { authenticated: true }, result.data);
+        Object.assign(req.feathers, { authenticated: true }, result.data);
+
+        if (options.successRedirect && !options.__oauth) {
+          debug('Redirecting to ' + options.successRedirect);
+          res.status(302);
+          return res.redirect(options.successRedirect);
+        }
+
+        return next();
+      }
+
+      if (result.fail) {
+        if (options.failureRedirect && !options.__oauth) {
+          debug('Redirecting to ' + options.failureRedirect);
+          res.status(302);
+          return res.redirect(options.failureRedirect);
+        }
+
+        var challenge = result.challenge,
+            _result$status = result.status,
+            status = _result$status === undefined ? 401 : _result$status;
+
+        var message = challenge && challenge.message ? challenge.message : challenge;
+
+        if (options.failureMessage) {
+          message = options.failureMessage;
+        }
+
+        res.status(status);
+        return Promise.reject(new _feathersErrors2.default[status](message, challenge));
+      }
+
+      if (result.redirect) {
+        debug('Redirecting to ' + result.url);
+        res.status(result.status);
+        return res.redirect(result.url);
+      }
+
+      // Only gets here if pass() is called by the strategy
+      next();
+    }).catch(next);
+  };
+}
+module.exports = exports['default'];

--- a/lib/express/emit-events.js
+++ b/lib/express/emit-events.js
@@ -1,0 +1,44 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.default = emitEvents;
+
+var _debug = require('debug');
+
+var _debug2 = _interopRequireDefault(_debug);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+var debug = (0, _debug2.default)('feathers-authentication:express:emit-events');
+
+function emitEvents() {
+  return function (req, res, next) {
+    var method = res.hook && res.hook.method;
+
+    var event = null;
+
+    if (method === 'remove') {
+      event = 'logout';
+    } else if (method === 'create') {
+      event = 'login';
+    }
+
+    if (res.data && res.data.accessToken && event) {
+      var app = req.app;
+
+
+      debug('Sending \'' + event + '\' event for REST provider. Token is', res.data.accessToken);
+
+      app.emit(event, res.data, {
+        provider: 'rest',
+        req: req,
+        res: res
+      });
+    }
+
+    next();
+  };
+}
+module.exports = exports['default'];

--- a/lib/express/expose-cookies.js
+++ b/lib/express/expose-cookies.js
@@ -1,0 +1,25 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+exports.default = function () {
+  debug('Registering exposeCookies middleware');
+
+  return function exposeCookies(req, res, next) {
+    debug('Exposing Express cookies to hooks and services', req.cookies);
+    req.feathers.cookies = req.cookies;
+    next();
+  };
+};
+
+var _debug = require('debug');
+
+var _debug2 = _interopRequireDefault(_debug);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+var debug = (0, _debug2.default)('feathers-authentication:express:expose-cookies');
+
+module.exports = exports['default'];

--- a/lib/express/expose-headers.js
+++ b/lib/express/expose-headers.js
@@ -1,0 +1,25 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+exports.default = function () {
+  debug('Registering exposeHeaders middleware');
+
+  return function exposeHeaders(req, res, next) {
+    debug('Exposing Express headers to hooks and services');
+    req.feathers.headers = req.headers;
+    next();
+  };
+};
+
+var _debug = require('debug');
+
+var _debug2 = _interopRequireDefault(_debug);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+var debug = (0, _debug2.default)('feathers-authentication:express:expose-headers');
+
+module.exports = exports['default'];

--- a/lib/express/failure-redirect.js
+++ b/lib/express/failure-redirect.js
@@ -1,0 +1,41 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.default = failureRedirect;
+
+var _debug = require('debug');
+
+var _debug2 = _interopRequireDefault(_debug);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+var debug = (0, _debug2.default)('feathers-authentication:middleware:failure-redirect');
+
+function failureRedirect() {
+  var options = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
+
+  debug('Registering failureRedirect middleware');
+
+  return function (error, req, res, next) {
+    if (options.cookie && options.cookie.enabled) {
+      debug('Clearing old \'' + options.cookie.name + '\' cookie');
+      res.clearCookie(options.cookie.name);
+    }
+
+    if (res.hook && res.hook.data && res.hook.data.__redirect) {
+      var _res$hook$data$__redi = res.hook.data.__redirect,
+          url = _res$hook$data$__redi.url,
+          status = _res$hook$data$__redi.status;
+
+      debug('Redirecting to ' + url + ' after failed authentication.');
+
+      res.status(status || 302);
+      return res.redirect(url);
+    }
+
+    next(error);
+  };
+}
+module.exports = exports['default'];

--- a/lib/express/index.js
+++ b/lib/express/index.js
@@ -1,0 +1,46 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _setCookie = require('./set-cookie');
+
+var _setCookie2 = _interopRequireDefault(_setCookie);
+
+var _successRedirect = require('./success-redirect');
+
+var _successRedirect2 = _interopRequireDefault(_successRedirect);
+
+var _failureRedirect = require('./failure-redirect');
+
+var _failureRedirect2 = _interopRequireDefault(_failureRedirect);
+
+var _authenticate = require('./authenticate');
+
+var _authenticate2 = _interopRequireDefault(_authenticate);
+
+var _exposeHeaders = require('./expose-headers');
+
+var _exposeHeaders2 = _interopRequireDefault(_exposeHeaders);
+
+var _exposeCookies = require('./expose-cookies');
+
+var _exposeCookies2 = _interopRequireDefault(_exposeCookies);
+
+var _emitEvents = require('./emit-events');
+
+var _emitEvents2 = _interopRequireDefault(_emitEvents);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+exports.default = {
+  exposeHeaders: _exposeHeaders2.default,
+  exposeCookies: _exposeCookies2.default,
+  authenticate: _authenticate2.default,
+  setCookie: _setCookie2.default,
+  successRedirect: _successRedirect2.default,
+  failureRedirect: _failureRedirect2.default,
+  emitEvents: _emitEvents2.default
+};
+module.exports = exports['default'];

--- a/lib/express/set-cookie.js
+++ b/lib/express/set-cookie.js
@@ -1,0 +1,86 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.default = setCookie;
+
+var _debug = require('debug');
+
+var _debug2 = _interopRequireDefault(_debug);
+
+var _lodash = require('lodash.omit');
+
+var _lodash2 = _interopRequireDefault(_lodash);
+
+var _ms = require('ms');
+
+var _ms2 = _interopRequireDefault(_ms);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+var debug = (0, _debug2.default)('feathers-authentication:middleware:set-cookie');
+
+function setCookie() {
+  var authOptions = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
+
+  debug('Registering setCookie middleware');
+
+  function makeExpiry(timeframe) {
+    return new Date(Date.now() + (0, _ms2.default)(timeframe));
+  }
+
+  return function (req, res, next) {
+    var app = req.app;
+    // Prevent mutating authOptions object
+    var options = Object.assign({}, authOptions.cookie);
+
+    debug('Running setCookie middleware with options:', options);
+
+    // If cookies are enabled then set it with its options.
+    if (options.enabled && options.name) {
+      var cookie = options.name;
+
+      // Only set the cookie if this was called after a service method and
+      // we weren't removing the token and we have a JWT access token.
+      if (res.hook && res.hook.method !== 'remove' && res.data && res.data.accessToken) {
+        // Clear out any old cookie since we are creating a new one
+        debug('Clearing old \'' + cookie + '\' cookie');
+        res.clearCookie(cookie);
+
+        // Check HTTPS and cookie status in production.
+        if (!req.secure && app.get('env') === 'production' && options.secure) {
+          console.warn('WARN: Request isn\'t served through HTTPS: JWT in the cookie is exposed.');
+          console.info('If you are behind a proxy (e.g. NGINX) you can:');
+          console.info('- trust it: http://expressjs.com/en/guide/behind-proxies.html');
+          console.info('- set cookie[\'' + cookie + '\'].secure false');
+        }
+
+        // If a custom expiry wasn't passed then set the expiration
+        // to be that of the JWT expiration or the maxAge option if provided.
+        if (options.expires === undefined) {
+          if (options.maxAge) {
+            options.expires = makeExpiry(options.maxAge);
+          } else if (authOptions.jwt.expiresIn) {
+            options.expires = makeExpiry(authOptions.jwt.expiresIn);
+          }
+        }
+
+        // Ensure that if a custom expiration was passed it is a valid date
+        if (options.expires && !(options.expires instanceof Date)) {
+          return next(new Error('cookie.expires must be a valid Date object'));
+        }
+
+        // remove some of our options that don't apply to express cookie creation
+        // as well as the maxAge because we have set an explicit expiry.
+        var cookieOptions = (0, _lodash2.default)(options, 'name', 'enabled', 'maxAge');
+
+        debug('Setting \'' + cookie + '\' cookie with options', cookieOptions);
+        res.cookie(cookie, res.data.accessToken, cookieOptions);
+      }
+    }
+
+    next();
+  };
+}
+module.exports = exports['default'];

--- a/lib/express/success-redirect.js
+++ b/lib/express/success-redirect.js
@@ -1,0 +1,34 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.default = successRedirect;
+
+var _debug = require('debug');
+
+var _debug2 = _interopRequireDefault(_debug);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+var debug = (0, _debug2.default)('feathers-authentication:middleware:success-redirect');
+
+function successRedirect() {
+  debug('Registering successRedirect middleware');
+
+  return function (req, res, next) {
+    if (res.hook && res.hook.data && res.hook.data.__redirect) {
+      var _res$hook$data$__redi = res.hook.data.__redirect,
+          url = _res$hook$data$__redi.url,
+          status = _res$hook$data$__redi.status;
+
+      debug('Redirecting to ' + url + ' after successful authentication.');
+
+      res.status(status || 302);
+      return res.redirect(url);
+    }
+
+    next();
+  };
+}
+module.exports = exports['default'];

--- a/lib/hooks/authenticate.js
+++ b/lib/hooks/authenticate.js
@@ -1,0 +1,126 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.default = authenticate;
+
+var _feathersErrors = require('feathers-errors');
+
+var _feathersErrors2 = _interopRequireDefault(_feathersErrors);
+
+var _debug = require('debug');
+
+var _debug2 = _interopRequireDefault(_debug);
+
+var _lodash = require('lodash.merge');
+
+var _lodash2 = _interopRequireDefault(_lodash);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+var debug = (0, _debug2.default)('feathers-authentication:hooks:authenticate');
+
+function authenticate(strategies) {
+  var options = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+
+  if (!strategies) {
+    throw new Error('The \'authenticate\' hook requires one of your registered passport strategies.');
+  }
+
+  return function (hook) {
+    var app = hook.app;
+
+    // If called internally or we are already authenticated skip
+    if (!hook.params.provider || hook.params.authenticated) {
+      return Promise.resolve(hook);
+    }
+
+    if (hook.type !== 'before') {
+      return Promise.reject(new Error('The \'authenticate\' hook should only be used as a \'before\' hook.'));
+    }
+
+    hook.data = hook.data || {};
+
+    var strategy = hook.data.strategy;
+
+    if (!strategy) {
+      if (Array.isArray(strategies)) {
+        strategy = strategies[0];
+      } else {
+        strategy = strategies;
+      }
+    }
+
+    // Handle the case where authenticate hook was registered without a passport strategy specified
+    if (!strategy) {
+      return Promise.reject(new _feathersErrors2.default.GeneralError('You must provide an authentication \'strategy\''));
+    }
+
+    // The client must send a `strategy` name.
+    if (!app.passport._strategy(strategy)) {
+      return Promise.reject(new _feathersErrors2.default.BadRequest('Authentication strategy \'' + strategy + '\' is not registered.'));
+    }
+
+    // NOTE (EK): Passport expects an express/connect
+    // like request object. So we need to create one.
+    var request = {
+      query: hook.data,
+      body: hook.data,
+      params: hook.params,
+      headers: hook.params.headers || {},
+      cookies: hook.params.cookies || {},
+      session: {}
+    };
+
+    var strategyOptions = (0, _lodash2.default)({}, app.passport.options(strategy), options);
+
+    debug('Attempting to authenticate using ' + strategy + ' strategy with options', strategyOptions);
+
+    return app.authenticate(strategy, strategyOptions)(request).then(function () {
+      var result = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
+
+      if (result.fail && options.allowUnauthenticated !== true) {
+        // TODO (EK): Reject with something...
+        // You get back result.challenge and result.status
+        if (strategyOptions.failureRedirect) {
+          // TODO (EK): Bypass the service?
+          // hook.result = true
+          Object.defineProperty(hook.data, '__redirect', { value: { status: 302, url: strategyOptions.failureRedirect } });
+        }
+
+        var challenge = result.challenge,
+            _result$status = result.status,
+            status = _result$status === undefined ? 401 : _result$status;
+
+        var message = challenge && challenge.message ? challenge.message : challenge;
+
+        if (strategyOptions.failureMessage) {
+          message = strategyOptions.failureMessage;
+        }
+
+        return Promise.reject(new _feathersErrors2.default[status](message, challenge));
+      }
+
+      if (result.success || options.allowUnauthenticated === true) {
+        hook.params = Object.assign({ authenticated: result.success }, hook.params, result.data);
+
+        // Add the user to the original request object so it's available in the socket handler
+        Object.assign(request.params, hook.params);
+
+        if (strategyOptions.successRedirect) {
+          // TODO (EK): Bypass the service?
+          // hook.result = true
+          Object.defineProperty(hook.data, '__redirect', { value: { status: 302, url: strategyOptions.successRedirect } });
+        }
+      } else if (result.redirect) {
+        // TODO (EK): Bypass the service?
+        // hook.result = true
+        Object.defineProperty(hook.data, '__redirect', { value: { status: result.status, url: result.url } });
+      }
+
+      return Promise.resolve(hook);
+    });
+  };
+}
+module.exports = exports['default'];

--- a/lib/hooks/index.js
+++ b/lib/hooks/index.js
@@ -1,0 +1,16 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _authenticate = require('./authenticate');
+
+var _authenticate2 = _interopRequireDefault(_authenticate);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+exports.default = {
+  authenticate: _authenticate2.default
+};
+module.exports = exports['default'];

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,0 +1,116 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.default = init;
+
+var _debug = require('debug');
+
+var _debug2 = _interopRequireDefault(_debug);
+
+var _hooks = require('./hooks');
+
+var _hooks2 = _interopRequireDefault(_hooks);
+
+var _express = require('./express');
+
+var _express2 = _interopRequireDefault(_express);
+
+var _passport = require('passport');
+
+var _passport2 = _interopRequireDefault(_passport);
+
+var _passport3 = require('./passport');
+
+var _passport4 = _interopRequireDefault(_passport3);
+
+var _options = require('./options');
+
+var _options2 = _interopRequireDefault(_options);
+
+var _service = require('./service');
+
+var _service2 = _interopRequireDefault(_service);
+
+var _socket = require('./socket');
+
+var _socket2 = _interopRequireDefault(_socket);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+var debug = (0, _debug2.default)('feathers-authentication:index');
+
+function init() {
+  var config = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
+
+  return function authentication() {
+    var app = this;
+    var _super = app.setup;
+    // Merge and flatten options
+    var options = (0, _options2.default)(config);
+
+    if (app.passport) {
+      throw new Error('You have already registered authentication on this app. You only need to do it once.');
+    }
+
+    if (!options.secret) {
+      throw new Error('You must provide a \'secret\' in your authentication configuration');
+    }
+
+    // Make sure cookies don't have to be sent over HTTPS
+    // when in development or test mode.
+    if (app.get('env') === 'development' || app.get('env') === 'test') {
+      options.cookie.secure = false;
+    }
+
+    app.set('auth', options);
+
+    debug('Setting up Passport');
+    // Set up our framework adapter
+    _passport2.default.framework(_passport4.default.call(app, options));
+    // Expose passport on the app object
+    app.passport = _passport2.default;
+    // Alias to passport for less keystrokes
+    app.authenticate = _passport2.default.authenticate.bind(_passport2.default);
+    // Expose express request headers to Feathers services and hooks.
+    app.use(_express2.default.exposeHeaders());
+
+    if (options.cookie.enabled) {
+      // Expose express cookies to Feathers services and hooks.
+      debug('Setting up Express exposeCookie middleware');
+      app.use(_express2.default.exposeCookies());
+    }
+
+    // TODO (EK): Support passing your own service or force
+    // developer to register it themselves.
+    app.configure((0, _service2.default)(options));
+    app.passport.initialize();
+
+    app.setup = function () {
+      var result = _super.apply(this, arguments);
+
+      // Socket.io middleware
+      if (app.io) {
+        debug('registering Socket.io authentication middleware');
+        app.io.on('connection', _socket2.default.socketio(app, options));
+      }
+
+      // Primus middleware
+      if (app.primus) {
+        debug('registering Primus authentication middleware');
+        app.primus.on('connection', _socket2.default.primus(app, options));
+      }
+
+      return result;
+    };
+  };
+}
+
+// Exposed Modules
+Object.assign(init, {
+  hooks: _hooks2.default,
+  express: _express2.default,
+  service: _service2.default
+});
+module.exports = exports['default'];

--- a/lib/options.js
+++ b/lib/options.js
@@ -1,0 +1,44 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+exports.default = function () {
+  for (var _len = arguments.length, otherOptions = Array(_len), _key = 0; _key < _len; _key++) {
+    otherOptions[_key] = arguments[_key];
+  }
+
+  return _lodash2.default.apply(undefined, [{}, defaults].concat(otherOptions));
+};
+
+var _lodash = require('lodash.merge');
+
+var _lodash2 = _interopRequireDefault(_lodash);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+var defaults = {
+  path: '/authentication',
+  header: 'Authorization',
+  entity: 'user',
+  service: 'users',
+  passReqToCallback: true,
+  session: false,
+  cookie: {
+    enabled: false,
+    name: 'feathers-jwt',
+    httpOnly: false,
+    secure: true
+  },
+  jwt: {
+    header: { typ: 'access' }, // by default is an access token but can be any type
+    audience: 'https://yourdomain.com', // The resource server where the token is processed
+    subject: 'anonymous', // Typically the entity id associated with the JWT
+    issuer: 'feathers', // The issuing server, application or resource
+    algorithm: 'HS256',
+    expiresIn: '1d'
+  }
+};
+
+module.exports = exports['default'];

--- a/lib/passport/authenticate.js
+++ b/lib/passport/authenticate.js
@@ -1,0 +1,136 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.default = authenticate;
+
+var _debug = require('debug');
+
+var _debug2 = _interopRequireDefault(_debug);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; } /*
+                                                                                                                                                                                                                   * An authentication function that is called by
+                                                                                                                                                                                                                   * app.authenticate. Inspired by
+                                                                                                                                                                                                                   * https://github.com/jaredhanson/passport/blob/master/lib/middleware/authenticate.js
+                                                                                                                                                                                                                   */
+
+
+var debug = (0, _debug2.default)('feathers-authentication:passport:authenticate');
+
+function authenticate() {
+  var options = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
+
+  debug('Initializing custom passport authenticate', options);
+
+  // This function is bound by passport and called by passport.authenticate()
+  return function (passport, strategies) {
+    var strategyOptions = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : {};
+    var callback = arguments.length > 3 && arguments[3] !== undefined ? arguments[3] : function () {};
+
+    // This is called by the feathers middleware, hook or socket. The request object
+    // is a mock request derived from an http request, socket object, or hook.
+    return function () {
+      var request = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
+
+      return new Promise(function (resolve, reject) {
+        // TODO (EK): Support transformAuthInfo
+
+        // Allow you to set a location for the success payload.
+        // Default is hook.params.user, req.user and socket.user.
+        var entity = strategyOptions.entity || strategyOptions.assignProperty || options.entity;
+        request.body = request.body || {};
+        var strategyName = request.body.strategy;
+
+        if (!strategyName) {
+          if (Array.isArray(strategies)) {
+            strategyName = strategies[0];
+          } else {
+            strategyName = strategies;
+          }
+        }
+
+        if (!strategyName) {
+          return reject(new Error('You must provide an authentication \'strategy\''));
+        }
+
+        // Make sure `strategies` is an array, allowing authentication to pass through a chain of
+        // strategies.  The first name to succeed, redirect, or error will halt
+        // the chain.  Authentication failures will proceed through each strategy in
+        // series, ultimately failing if all strategies fail.
+        //
+        // This is typically used on API endpoints to allow clients to authenticate
+        // using their preferred choice of Basic, Digest, token-based schemes, etc.
+        // It is not feasible to construct a chain of multiple strategies that involve
+        // redirection (for example both Facebook and Twitter), since the first one to
+        // redirect will halt the chain.
+        if (!Array.isArray(strategies)) {
+          strategies = [strategies];
+        }
+
+        // Return an error if the client is trying to authenticate with a strategy
+        // that the server hasn't allowed for this authenticate call. This is important
+        // because it prevents the user from authenticating with a registered strategy
+        // that is not being allowed for this authenticate call.
+        if (!strategies.includes(strategyName)) {
+          return reject(new Error('Invalid authentication strategy \'' + strategyName + '\''));
+        }
+
+        // Get the strategy, which will be used as prototype from which to create
+        // a new instance.  Action functions will then be bound to the strategy
+        // within the context of the HTTP request/response pair.
+        var prototype = passport._strategy(strategyName);
+
+        if (!prototype) {
+          return reject(new Error('Unknown authentication strategy \'' + strategyName + '\''));
+        }
+
+        // Implement required passport methods that
+        // can be called by a passport strategy.
+        var strategy = Object.create(prototype);
+
+        strategy.redirect = function (url) {
+          var status = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : 302;
+
+          debug('\'' + strategyName + '\' authentication redirecting to', url, status);
+          resolve({ redirect: true, url: url, status: status });
+        };
+
+        strategy.fail = function (challenge, status) {
+          debug('Authentication strategy \'' + strategyName + '\' failed', challenge, status);
+          resolve({
+            fail: true,
+            challenge: challenge,
+            status: status
+          });
+        };
+
+        strategy.error = function (error) {
+          debug('Error in \'' + strategyName + '\' authentication strategy', error);
+          reject(error);
+        };
+
+        strategy.success = function (data, payload) {
+          var _data;
+
+          debug('\'' + strategyName + '\' authentication strategy succeeded', data, payload);
+          resolve({
+            success: true,
+            data: (_data = {}, _defineProperty(_data, entity, data), _defineProperty(_data, 'payload', payload), _data)
+          });
+        };
+
+        strategy.pass = function () {
+          debug('Passing on \'' + strategyName + '\' authentication strategy');
+          resolve();
+        };
+
+        debug('Passport request object', request);
+        strategy.authenticate(request, strategyOptions);
+      });
+    };
+  };
+}
+module.exports = exports['default'];

--- a/lib/passport/index.js
+++ b/lib/passport/index.js
@@ -1,0 +1,37 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.default = feathersPassport;
+
+var _initialize = require('./initialize');
+
+var _initialize2 = _interopRequireDefault(_initialize);
+
+var _authenticate = require('./authenticate');
+
+var _authenticate2 = _interopRequireDefault(_authenticate);
+
+var _debug = require('debug');
+
+var _debug2 = _interopRequireDefault(_debug);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+var debug = (0, _debug2.default)('feathers-authentication:passport'); /*
+                                                                       * A Feather Passport adapter so that it plays
+                                                                       * nicely with Feathers services but remains
+                                                                       * engine and transport agnostic.
+                                                                       */
+function feathersPassport(options) {
+  var app = this;
+
+  debug('Initializing Feathers passport adapter');
+
+  return {
+    initialize: _initialize2.default.call(app, options),
+    authenticate: _authenticate2.default.call(app, options)
+  };
+}
+module.exports = exports['default'];

--- a/lib/passport/initialize.js
+++ b/lib/passport/initialize.js
@@ -1,0 +1,51 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.default = initialize;
+
+var _debug = require('debug');
+
+var _debug2 = _interopRequireDefault(_debug);
+
+var _utils = require('../utils');
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+var debug = (0, _debug2.default)('feathers-authentication:passport:initialize');
+
+function initialize() {
+  var options = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
+
+  // const app = this;
+
+  debug('Initializing custom passport initialize', options);
+
+  // Do any special feathers passport initialization here. We may need this
+  // to support different engines.
+  return function (passport) {
+    // NOTE (EK): This is called by passport.initialize() when calling
+    // app.configure(authentication()).
+
+    // Expose our JWT util functions globally
+    passport._feathers = {};
+    passport.createJWT = _utils.createJWT;
+    passport.verifyJWT = _utils.verifyJWT;
+    passport.options = function (name, strategyOptions) {
+      if (!name) {
+        return passport._feathers;
+      }
+
+      if (typeof name === 'string' && !strategyOptions) {
+        return passport._feathers[name];
+      }
+
+      if (typeof name === 'string' && strategyOptions) {
+        debug('Setting ' + name + ' strategy options', strategyOptions);
+        passport._feathers[name] = Object.assign({}, strategyOptions);
+      }
+    };
+  };
+}
+module.exports = exports['default'];

--- a/lib/service.js
+++ b/lib/service.js
@@ -1,0 +1,94 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+exports.default = init;
+
+var _debug = require('debug');
+
+var _debug2 = _interopRequireDefault(_debug);
+
+var _lodash = require('lodash.merge');
+
+var _lodash2 = _interopRequireDefault(_lodash);
+
+var _express = require('./express');
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+var debug = (0, _debug2.default)('feathers-authentication:authentication:service');
+
+var Service = function () {
+  function Service(app) {
+    _classCallCheck(this, Service);
+
+    this.app = app;
+    this.passport = app.passport;
+  }
+
+  _createClass(Service, [{
+    key: 'create',
+    value: function create() {
+      var data = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
+      var params = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+
+      var defaults = this.app.get('auth');
+      var payload = (0, _lodash2.default)(data.payload, params.payload);
+
+      // create accessToken
+      // TODO (EK): Support refresh tokens
+      // TODO (EK): This should likely be a hook
+      // TODO (EK): This service can be datastore backed to support blacklists :)
+      return this.passport.createJWT(payload, (0, _lodash2.default)({}, defaults, params)).then(function (accessToken) {
+        return { accessToken: accessToken };
+      });
+    }
+  }, {
+    key: 'remove',
+    value: function remove(id, params) {
+      var defaults = this.app.get('auth');
+      var authHeader = params.headers && params.headers[defaults.header.toLowerCase()];
+      var authParams = authHeader && authHeader.match(/(\S+)\s+(\S+)/);
+      var accessToken = id !== null ? id : authParams && authParams[2] || authHeader;
+
+      // TODO (EK): return error if token is missing?
+      return this.passport.verifyJWT(accessToken, (0, _lodash2.default)(defaults, params)).then(function (payload) {
+        return { accessToken: accessToken };
+      });
+    }
+  }]);
+
+  return Service;
+}();
+
+function init(options) {
+  return function () {
+    var app = this;
+    var path = options.path;
+
+    if (typeof path !== 'string') {
+      throw new Error('You must provide a \'path\' in your authentication configuration or pass one explicitly.');
+    }
+
+    debug('Configuring authentication service at path', path);
+
+    app.use(path, new Service(app, options), (0, _express.emitEvents)(options), (0, _express.setCookie)(options), (0, _express.successRedirect)(), (0, _express.failureRedirect)(options));
+
+    var service = app.service(path);
+
+    if (typeof service.filter === 'function') {
+      service.filter(function () {
+        return false;
+      });
+    }
+  };
+}
+
+init.Service = Service;
+module.exports = exports['default'];

--- a/lib/socket/handler.js
+++ b/lib/socket/handler.js
@@ -1,0 +1,167 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.default = setupSocketHandler;
+
+var _debug = require('debug');
+
+var _debug2 = _interopRequireDefault(_debug);
+
+var _ms = require('ms');
+
+var _ms2 = _interopRequireDefault(_ms);
+
+var _utils = require('feathers-socket-commons/lib/utils');
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
+
+var debug = (0, _debug2.default)('feathers-authentication:sockets:handler');
+
+function handleSocketCallback(promise, callback) {
+  if (typeof callback === 'function') {
+    promise.then(function (data) {
+      return callback(null, data);
+    }).catch(function (error) {
+      debug('Socket authentication error', error);
+      callback((0, _utils.normalizeError)(error));
+    });
+  }
+
+  return promise;
+}
+
+function setupSocketHandler(app, options, _ref) {
+  var feathersParams = _ref.feathersParams,
+      provider = _ref.provider,
+      emit = _ref.emit,
+      disconnect = _ref.disconnect;
+
+  var authSettings = app.get('auth');
+  var service = app.service(authSettings.path);
+
+  return function (socket) {
+    var logoutTimer = void 0;
+
+    var logout = function logout() {
+      var callback = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : function () {};
+
+      var connection = feathersParams(socket);
+      var accessToken = connection.accessToken;
+
+
+      if (accessToken) {
+        debug('Logging out socket with accessToken', accessToken);
+
+        delete connection.accessToken;
+        delete connection.authenticated;
+        connection.headers = {};
+        socket._feathers.body = {};
+
+        var promise = service.remove(accessToken, { authenticated: true }).then(function (tokens) {
+          debug('Successfully logged out socket with accessToken', accessToken);
+
+          app.emit('logout', tokens, {
+            provider: provider,
+            socket: socket,
+            connection: connection
+          });
+
+          return tokens;
+        });
+
+        handleSocketCallback(promise, callback);
+      } else if (typeof callback === 'function') {
+        return callback(null, {});
+      }
+    };
+
+    var authenticate = function authenticate(data) {
+      var callback = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : function () {};
+      var strategy = data.strategy;
+
+      socket._feathers = {
+        query: {},
+        provider: 'socketio',
+        headers: {},
+        session: {},
+        cookies: {}
+      };
+
+      var strategyOptions = app.passport.options(strategy);
+
+      var promise = service.create(data, socket._feathers).then(function (tokens) {
+        if (socket._feathers.authenticated) {
+          // Add the auth strategy response data and tokens to the socket connection
+          // so that they can be referenced in the future. (ie. attach the user)
+          var connection = feathersParams(socket);
+          var headers = _defineProperty({}, authSettings.header, tokens.accessToken);
+          var result = _defineProperty({
+            payload: socket._feathers.payload
+          }, strategyOptions.entity, socket._feathers[strategyOptions.entity]);
+
+          connection = Object.assign(connection, result, tokens, { headers: headers, authenticated: true });
+
+          app.emit('login', tokens, {
+            provider: provider,
+            socket: socket,
+            connection: connection
+          });
+        }
+
+        // Clear any previous timeout if we have logged in again.
+        if (logoutTimer) {
+          debug('Clearing old timeout.');
+          clearTimeout(logoutTimer);
+        }
+
+        logoutTimer = setTimeout(function () {
+          debug('Token expired. Logging out.');
+          logout();
+        }, (0, _ms2.default)(authSettings.jwt.expiresIn));
+
+        // TODO (EK): Setup and tear down socket listeners to keep the entity
+        // up to date that should be attached to the socket. Need to get the
+        // entity or assignProperty
+        //
+        // Remove old listeners to prevent leaks
+        // socket.off('users updated');
+        // socket.off('users patched');
+        // socket.off('users removed');
+
+        // Register new event listeners
+        // socket.on('users updated', data => {
+        //   if (data.id === id) {
+        //     let connection = feathersParams(socket);
+        //     connection.user = data;
+        //   }
+        // });
+
+        // socket.on('users patched', data => {
+        //   if (data.id === id) {
+        //     let connection = feathersParams(socket);
+        //     connection.user = data;
+        //   }
+        // });
+
+        // socket.on('users removed', data => {
+        //   if (data.id === id) {
+        //     logout();
+        //   }
+        // });
+
+        return Promise.resolve(tokens);
+      });
+
+      handleSocketCallback(promise, callback);
+    };
+
+    socket.on('authenticate', authenticate);
+    socket.on(disconnect, logout);
+    socket.on('logout', logout);
+  };
+}
+module.exports = exports['default'];

--- a/lib/socket/index.js
+++ b/lib/socket/index.js
@@ -1,0 +1,58 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.socketio = socketio;
+exports.primus = primus;
+
+var _debug = require('debug');
+
+var _debug2 = _interopRequireDefault(_debug);
+
+var _handler = require('./handler');
+
+var _handler2 = _interopRequireDefault(_handler);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+var debug = (0, _debug2.default)('feathers-authentication:sockets');
+
+function socketio(app) {
+  var options = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+
+  debug('Setting up Socket.io authentication middleware with options:', options);
+
+  var providerSettings = {
+    provider: 'socketio',
+    emit: 'emit',
+    disconnect: 'disconnect',
+    feathersParams: function feathersParams(socket) {
+      return socket.feathers;
+    }
+  };
+
+  return (0, _handler2.default)(app, options, providerSettings);
+}
+
+function primus(app) {
+  var options = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+
+  debug('Setting up Primus authentication middleware with options:', options);
+
+  var providerSettings = {
+    provider: 'primus',
+    emit: 'send',
+    disconnect: 'end',
+    feathersParams: function feathersParams(socket) {
+      return socket.request.feathers;
+    }
+  };
+
+  return (0, _handler2.default)(app, options, providerSettings);
+}
+
+exports.default = {
+  socketio: socketio,
+  primus: primus
+};

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,0 +1,92 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.createJWT = createJWT;
+exports.verifyJWT = verifyJWT;
+
+var _debug = require('debug');
+
+var _debug2 = _interopRequireDefault(_debug);
+
+var _lodash = require('lodash.pick');
+
+var _lodash2 = _interopRequireDefault(_lodash);
+
+var _lodash3 = require('lodash.omit');
+
+var _lodash4 = _interopRequireDefault(_lodash3);
+
+var _jsonwebtoken = require('jsonwebtoken');
+
+var _jsonwebtoken2 = _interopRequireDefault(_jsonwebtoken);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+var debug = (0, _debug2.default)('feathers-authentication:authentication:utils');
+
+function createJWT() {
+  var payload = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};
+  var options = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+
+  var VALID_KEYS = ['algorithm', 'expiresIn', 'notBefore', 'audience', 'issuer', 'jwtid', 'subject', 'noTimestamp', 'header', 'exp', 'nbf', 'aud', 'sub', 'iss'];
+  var settings = Object.assign({}, options.jwt);
+  var secret = options.secret;
+
+
+  return new Promise(function (resolve, reject) {
+    debug('Creating JWT using options', settings);
+
+    if (!secret) {
+      return reject(new Error('secret must provided'));
+    }
+
+    // TODO (EK): Support jwtids. Maybe auto-generate a uuid
+    _jsonwebtoken2.default.sign((0, _lodash4.default)(payload, VALID_KEYS), secret, (0, _lodash2.default)(settings, VALID_KEYS), function (error, token) {
+      if (error) {
+        debug('Error signing JWT', error);
+        return reject(error);
+      }
+
+      debug('New JWT issued with payload', payload);
+      return resolve(token);
+    });
+  });
+}
+
+function verifyJWT(token) {
+  var options = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
+
+  var VALID_KEYS = ['algorithms', 'audience', 'issuer', 'ignoreExpiration', 'ignoreNotBefore', 'subject', 'clockTolerance'];
+  var settings = Object.assign({}, options.jwt);
+  var secret = options.secret;
+
+  // normalize algorithm to array
+
+  if (settings.algorithm) {
+    settings.algorithms = Array.isArray(settings.algorithm) ? settings.algorithm : [settings.algorithm];
+    delete settings.algorithm;
+  }
+
+  return new Promise(function (resolve, reject) {
+    if (!token) {
+      return reject(new Error('token must provided'));
+    }
+
+    if (!secret) {
+      return reject(new Error('secret must provided'));
+    }
+
+    debug('Verifying token', token);
+    _jsonwebtoken2.default.verify(token, secret, (0, _lodash2.default)(settings, VALID_KEYS), function (error, payload) {
+      if (error) {
+        debug('Error verifying token', error);
+        return reject(error);
+      }
+
+      debug('Verified token with payload', payload);
+      resolve(payload);
+    });
+  });
+}

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "release:major": "npm version major && npm publish",
     "release:pre": "npm publish --tag next",
     "changelog": "github_changelog_generator && git add CHANGELOG.md && git commit -am \"Updating changelog\"",
-    "compile": "rimraf -rf lib/ && babel -d lib/ src/",
+    "compile": "rimraf lib/ && babel -d lib/ src/",
     "watch": "babel --watch -d lib/ src/",
     "lint": "semistandard --fix",
     "mocha": "mocha --opts mocha.opts",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,9 @@
   },
   "semistandard": {
     "sourceType": "module",
+    "ignore": [
+      "/lib/"
+    ],
     "env": [
       "mocha"
     ]

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "start": "node example/app",
     "prepublish": "npm run compile",
     "publish": "git push origin && git push origin --tags",
-    "postinstall": "npm run compile",
     "release:patch": "npm version patch && npm publish",
     "release:minor": "npm version minor && npm publish",
     "release:major": "npm version major && npm publish",

--- a/src/hooks/authenticate.js
+++ b/src/hooks/authenticate.js
@@ -58,7 +58,7 @@ export default function authenticate (strategy, options = {}) {
       }
 
       if (result.success || options.allowUnauthenticated === true) {
-        hook.params = Object.assign({ authenticated: result.success?true:false }, hook.params, result.data);
+        hook.params = Object.assign({ authenticated: result.success }, hook.params, result.data);
         if (options.successRedirect) {
           // TODO (EK): Bypass the service?
           // hook.result = true

--- a/src/hooks/authenticate.js
+++ b/src/hooks/authenticate.js
@@ -38,7 +38,7 @@ export default function authenticate (strategy, options = {}) {
     debug(`Attempting to authenticate using ${strategy} strategy with options`, options);
 
     return app.authenticate(strategy, options)(request).then((result = {}) => {
-      if (result.fail) {
+      if (result.fail && options.allowUnauthenticated!==true ) {
         // TODO (EK): Reject with something...
         // You get back result.challenge and result.status
         if (options.failureRedirect) {
@@ -57,7 +57,7 @@ export default function authenticate (strategy, options = {}) {
         return Promise.reject(new errors[status](message, challenge));
       }
 
-      if (result.success) {
+      if (result.success || options.allowUnauthenticated === true) {
         hook.params = Object.assign({ authenticated: true }, hook.params, result.data);
         if (options.successRedirect) {
           // TODO (EK): Bypass the service?

--- a/src/hooks/authenticate.js
+++ b/src/hooks/authenticate.js
@@ -38,7 +38,7 @@ export default function authenticate (strategy, options = {}) {
     debug(`Attempting to authenticate using ${strategy} strategy with options`, options);
 
     return app.authenticate(strategy, options)(request).then((result = {}) => {
-      if (result.fail && options.allowUnauthenticated!==true ) {
+      if (result.fail && options.allowUnauthenticated !== true) {
         // TODO (EK): Reject with something...
         // You get back result.challenge and result.status
         if (options.failureRedirect) {
@@ -58,7 +58,7 @@ export default function authenticate (strategy, options = {}) {
       }
 
       if (result.success || options.allowUnauthenticated === true) {
-        hook.params = Object.assign({ authenticated: true }, hook.params, result.data);
+        hook.params = Object.assign({ authenticated: result.success?true:false }, hook.params, result.data);
         if (options.successRedirect) {
           // TODO (EK): Bypass the service?
           // hook.result = true


### PR DESCRIPTION
This adds to option `allowUnauthenticated` which makes it possible to authenticate the user, but also allow anonymouse users to pass the hook too.

```
auth.hooks.authenticate('jwt', {allowUnauthenticated: true})
```

Its required if you want to allow certain stuff to be done by anonymous users.