### PR TITLE
Add a 'is owner or restrict changes hook'

### DIFF
--- a/src/hooks/index.js
+++ b/src/hooks/index.js
@@ -9,6 +9,7 @@ import verifyToken from './verify-token';
 import verifyOrRestrict from './verify-or-restrict';
 import populateOrRestrict from './populate-or-restrict';
 import hasRoleOrRestrict from './has-role-or-restrict';
+import ownerOrRestrictChanges from './owner-or-restrict-changes';
 
 let hooks = {
   associateCurrentUser,
@@ -21,7 +22,8 @@ let hooks = {
   verifyToken,
   verifyOrRestrict,
   populateOrRestrict,
-  hasRoleOrRestrict
+  hasRoleOrRestrict,
+  ownerOrRestrictChanges
 };
 
 export default hooks;

--- a/src/hooks/owner-or-restrict-changes.js
+++ b/src/hooks/owner-or-restrict-changes.js
@@ -1,0 +1,125 @@
+import errors from 'feathers-errors';
+import _ from 'lodash';
+
+const defaults = {
+  idField: '_id',
+  ownerField: 'userId'
+};
+
+function getRestrictions(restrictions, user, data) {
+  const name = _.get(user, 'name') || _.get(user, 'email') || 'You';
+
+  // Make restrictions an array if it's not
+  restrictions = _.castArray(restrictions);
+
+  var includeS = '';
+
+  const restrictionsString = _
+    .chain(restrictions)
+    .map(restriction => _.has(data, restriction)? restriction: null)
+    .compact()
+    .value()
+    .join(', ');
+
+  if(!restrictionsString) { return null; }
+
+  var restrictionsStringModified;
+
+  if(restrictionsString.split(',').length > 0) {
+    restrictionsStringModified = restrictionsString.replace(/,(?!.*,)/gmi, ' or');
+    if(restrictionsString.split(',').length > 1) {
+      includeS = 's';
+    }
+  }
+
+  return `${name} ${name === 'You'? 'are' : 'is'} not permitted to update the ${restrictionsStringModified} field${includeS}.`;
+}
+
+export default function(options = {}){
+  return function(hook) {
+    if (hook.type !== 'before') {
+      throw new Error(`The 'ownerOrRestrictChanges' hook should only be used as a 'before' hook.`);
+    }
+
+    if (hook.method !== 'update' && hook.method !== 'patch') {
+      throw new errors.MethodNotAllowed(`The 'ownerOrRestrictChanges' hook should only be used on the 'update' or 'patch' service methods.`);
+    }
+
+    if(!hook.id) {
+      throw new errors.MethodNotAllowed(`The hook.id for the item must be supplied.`);
+    }
+
+    // If it was an internal call then skip this hook
+    if (!hook.params.provider) {
+      return hook;
+    }
+
+    let restrictionMessage = '';
+
+    if (!hook.params.user) {
+      restrictionMessage = getRestrictions(options.restrictOn, _.get(hook, 'params.user'), hook.data);
+
+      if(restrictionMessage) {
+        throw new errors.Forbidden(restrictionMessage);
+      } else {
+        return hook;
+      }
+    }
+
+    options = Object.assign({}, defaults, hook.app.get('auth'), options);
+
+    const id = hook.params.user[options.idField];
+
+    if (id === undefined) {
+      throw new Error(`'${options.idField} is missing from current user.'`);
+    }
+
+    // look up the document and throw a Forbidden error if the user is not an owner and tries to change restricted fields
+    return new Promise((resolve, reject) => {
+      // Set provider as undefined so we avoid an infinite loop if this hook is
+      // set on the resource we are requesting.
+      const params = Object.assign({}, hook.params, { provider: undefined });
+
+      return this.get(hook.id, params).then(data => {
+        if (data.toJSON) {
+          data = data.toJSON();
+        }
+        else if (data.toObject) {
+          data = data.toObject();
+        }
+
+        let field = data[options.ownerField];
+
+        // Handle nested Sequelize or Mongoose models
+        if (_.isPlainObject(field)) {
+          field = field[options.idField];
+        }
+
+        if (Array.isArray(field)) {
+          const fieldArray = field.map(idValue => idValue.toString());
+          if (fieldArray.length === 0 || fieldArray.indexOf(id.toString()) < 0) {
+
+            restrictionMessage = getRestrictions(options.restrictOn, _.get(hook, 'params.user'), hook.data);
+
+            if(restrictionMessage) {
+              throw new errors.Forbidden(restrictionMessage);
+            } else {
+              return resolve(hook);
+            }
+          }
+        } else if ( field === undefined || field.toString() !== id.toString() ) {
+
+          restrictionMessage = getRestrictions(options.restrictOn, _.get(hook, 'params.user'), hook.data);
+
+          if(restrictionMessage) {
+            throw new errors.Forbidden(restrictionMessage);
+          } else {
+            return resolve(hook);
+          }
+        }
+
+        resolve(hook);
+      }).catch(reject);
+    });
+  };
+}

--- a/test/src/hooks/index.test.js
+++ b/test/src/hooks/index.test.js
@@ -46,6 +46,10 @@ describe('Auth hooks', () => {
     expect(typeof hooks.verifyOrRestrict).to.equal('function');
   });
 
+  it('exposes ownerOrRestrictChanges hook', () => {
+    expect(typeof hooks.ownerOrRestrictChanges).to.equal('function');
+  });
+
   it('exposes populateOrRestrict hook', () => {
     expect(typeof hooks.populateOrRestrict).to.equal('function');
   });

--- a/test/src/hooks/owner-or-restrict-changes.js
+++ b/test/src/hooks/owner-or-restrict-changes.js
@@ -1,0 +1,213 @@
+import { ownerOrRestrictChanges } from '../../../src/hooks';
+
+import chai, { expect } from 'chai';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+chai.use(sinonChai);
+
+const mockPatch = sinon.stub().returns(Promise.resolve([{text: 'test', approved: true}]));
+const mockGet = sinon.stub().returns(Promise.resolve({
+  toJSON: function() {
+    return {
+      _id: '123',
+      text: 'test',
+      approved: true,
+      userId: '1'
+    };
+  }
+}));
+const mockService = {
+  patch: mockPatch
+};
+
+describe('ownerOrRestrictChanges', () => {
+  describe('when not called as a before hook', () => {
+    it('throws an error', () => {
+      let hook = {
+        type: 'after',
+        method: 'patch'
+      };
+
+      try {
+        ownerOrRestrictChanges()(hook);
+      }
+      catch(error) {
+        expect(error).to.not.equal(undefined);
+      }
+    });
+  });
+
+  describe('when provider does not exist', () => {
+    it('does not do anything', () => {
+      let hook = {
+        type: 'before',
+        method: 'patch',
+        id: '123',
+        params: {}
+      };
+
+      try {
+        var returnedHook = ownerOrRestrictChanges()(hook);
+        expect(hook).to.deep.equal(returnedHook);
+      }
+      catch(error) {
+        // It should never get here
+        expect(false).to.equal(true);
+      }
+    });
+  });
+
+  describe('when hook.id is not set', () => {
+    it('should throw an error', () => {
+      let hook = {
+        type: 'before',
+        method: 'patch',
+        params: {}
+      };
+
+      try {
+        ownerOrRestrictChanges()(hook);
+      } catch(error) {
+        // It should never get here
+        expect(error).to.not.equal(undefined);
+      }
+    });
+  });
+
+  describe('when the user is not authenticated', () => {
+    it('should throw an error if restricted changes are attempted', () => {
+      let hook = {
+        method: 'patch',
+        app: {
+          service: mockService
+        },
+        data: {
+          author: 'James',
+          approved: false
+        },
+        id: '123',
+        type: 'before',
+        params: {
+          provider: 'rest'
+        }
+      };
+
+      try {
+        ownerOrRestrictChanges({ restrictOn: ['approved'] })(hook);
+      } catch(error) {
+        expect(error).to.not.equal(undefined);
+      }
+    });
+
+    it('should authorize unrestricted changes', () => {
+      let hook = {
+        method: 'patch',
+        app: {
+          service: mockService
+        },
+        data: {
+          author: 'James',
+          pizza: 5
+        },
+        id: '123',
+        type: 'before',
+        params: {
+          provider: 'rest'
+        }
+      };
+
+      try {
+        ownerOrRestrictChanges({ restrictOn: ['approved'] })(hook);
+      } catch(error) {
+        expect(error).to.not.equal(undefined);
+      }
+    });
+  });
+
+  describe('when user is not the owner', (done) => {
+    it('should throw an error if restricted changes are attempted', () => {
+      let hook = {
+        method: 'patch',
+        app: {
+          service: mockService,
+          get: function() {
+            return {};
+          }
+        },
+        data: {
+          author: 'James',
+          approved: false,
+          pizza: 'cheese'
+        },
+        id: '123',
+        type: 'before',
+        params: {
+          user: { _id: '2' },
+          provider: 'rest'
+        }
+      };
+
+      ownerOrRestrictChanges({ restrictOn: ['approved', 'pizza'] }).call({ get: mockGet }, hook).then(function() {}, function(error) {
+        expect(error).to.not.equal(undefined);
+        done();
+      });
+    });
+    it('should authorize unrestricted changes', (done) => {
+      let hook = {
+        method: 'patch',
+        app: {
+          service: mockService,
+          get: function() {
+            return {};
+          }
+        },
+        data: {
+          author: 'James',
+          pizza: 'bacon'
+        },
+        id: '123',
+        type: 'before',
+        params: {
+          user: { _id: '2' },
+          provider: 'rest'
+        }
+      };
+
+      ownerOrRestrictChanges({ restrictOn: ['approved'] }).call({ get: mockGet }, hook).then(function(response) {
+        expect(response).to.deep.equal(hook);
+        done();
+      });
+    });
+  });
+
+  describe('when user is the owner', () => {
+    it('should authorize all changes', (done) => {
+      let hook = {
+        method: 'patch',
+        app: {
+          service: mockService,
+          get: function() {
+            return {};
+          }
+        },
+        data: {
+          author: 'James',
+          approved: false,
+          pizza: 'pepporoni'
+        },
+        id: '123',
+        type: 'before',
+        params: {
+          user: { _id: '1' },
+          provider: 'rest'
+        }
+      };
+
+      ownerOrRestrictChanges({ restrictOn: ['approved', 'pizza'] }).call({ get: mockGet }, hook).then(function(response) {
+        expect(response).to.deep.equal(hook);
+        done();
+      });
+    });
+  });
+
+});


### PR DESCRIPTION
Only the owner of the document has the ability to modify their document without restriction. Unauthenticated users or users that don't own the document can still make changes but are restricted to using certain properties.