### PR TITLE
Fix Oauth callback receive array instead of model instance

### DIFF
--- a/src/services/oauth2.js
+++ b/src/services/oauth2.js
@@ -61,7 +61,7 @@ export class Service {
           debug(`Updating user: ${id}`);
 
           return app.service(options.userEndpoint).patch(id, data).then(updatedUser => {
-            return done(null, updatedUser);
+            return done(null, updatedUser[0]);
           }).catch(done);
         }
 


### PR DESCRIPTION
Some of service adapters like feathers-sequelize or feathers-moongo implemented `patch` action that will return an array of instances.

For example feathers-sequelize, this is the way we're using to updating database in `patch` action

[https://github.com/feathersjs/feathers-sequelize/blob/master/src/index.js#L134](https://github.com/feathersjs/feathers-sequelize/blob/master/src/index.js#L134)

Follow documentation of sequelize, 
[http://docs.sequelizejs.com/en/latest/api/model/#updatevalues-options-promisearrayaffectedcount-affectedrows](http://docs.sequelizejs.com/en/latest/api/model/#updatevalues-options-promisearrayaffectedcount-affectedrows)

The `update` method of Model will update multiple instances that match the where options and returns an array of those instances.

I knew that we're moving to `v.1.0` but this's a bug in legacy repo