### PR TITLE
Resolves #475 - Socket params are made available to authentication hooks

### DIFF
--- a/src/socket/handler.js
+++ b/src/socket/handler.js
@@ -55,13 +55,13 @@ export default function setupSocketHandler (app, options, { feathersParams, prov
 
     const authenticate = function (data, callback = () => {}) {
       const { strategy } = data;
-      socket._feathers = {
+      socket._feathers = Object.assign({
         query: {},
         provider: 'socketio',
         headers: {},
         session: {},
         cookies: {}
-      };
+      }, feathersParams(socket));
 
       const strategyOptions = app.passport.options(strategy);
 

--- a/test/integration/primus.test.js
+++ b/test/integration/primus.test.js
@@ -14,6 +14,12 @@ describe('Primus authentication', function () {
     secret: 'supersecret',
     jwt: { expiresIn: '500ms' }
   }, 'primus');
+  const hook = sinon.spy(function (hook) {});
+  app.service('authentication').hooks({
+    before: {
+      create: [ hook ]
+    }
+  });
 
   let server;
   let socket;
@@ -55,6 +61,10 @@ describe('Primus authentication', function () {
     });
   });
 
+  afterEach(() => {
+    hook.reset();
+  });
+
   after(() => {
     expiringServer.close();
     server.close();
@@ -85,6 +95,7 @@ describe('Primus authentication', function () {
               expect(payload).to.exist;
               expect(payload.iss).to.equal('feathers');
               expect(payload.userId).to.equal(0);
+              expect(hook).to.be.calledWith(sinon.match({ params: { data: 'Hello world' } }));
               done();
             });
           });

--- a/test/integration/socketio.test.js
+++ b/test/integration/socketio.test.js
@@ -15,6 +15,12 @@ describe('Socket.io authentication', function () {
     secret: 'supersecret',
     jwt: { expiresIn: '500ms' }
   }, 'socketio');
+  const hook = sinon.spy(function (hook) {});
+  app.service('authentication').hooks({
+    before: {
+      create: [ hook ]
+    }
+  });
 
   let server;
   let socket;
@@ -49,6 +55,10 @@ describe('Socket.io authentication', function () {
     socket = io(baseURL);
   });
 
+  afterEach(() => {
+    hook.reset();
+  });
+
   after(() => {
     expiringServer.close();
     server.close();
@@ -79,6 +89,7 @@ describe('Socket.io authentication', function () {
               expect(payload).to.exist;
               expect(payload.iss).to.equal('feathers');
               expect(payload.userId).to.equal(0);
+              expect(hook).to.be.calledWith(sinon.match({ params: { data: 'Hello world' } }));
               done();
             });
           });


### PR DESCRIPTION
Makes those parameters specified in `socket.feathers.data` or `req.feathers.data`, when setting up SocketIO and Primus respectively, available to the authentication hooks as they would be elsewhere in a Feathers application.

Resolves #475