### PR TITLE
Fix issue with very large token timeout.

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "lodash.merge": "^4.6.0",
     "lodash.omit": "^4.5.0",
     "lodash.pick": "^4.4.0",
+    "long-timeout": "^0.1.1",
     "ms": "^1.0.0",
     "passport": "^0.3.2"
   },

--- a/src/socket/handler.js
+++ b/src/socket/handler.js
@@ -1,6 +1,7 @@
 import Debug from 'debug';
 import ms from 'ms';
 import { normalizeError } from 'feathers-socket-commons/lib/utils';
+import lt from 'long-timeout';
 
 const debug = Debug('feathers-authentication:sockets:handler');
 
@@ -94,7 +95,7 @@ export default function setupSocketHandler (app, options, { feathersParams, prov
             clearTimeout(logoutTimer);
           }
 
-          logoutTimer = setTimeout(() => {
+          logoutTimer = lt.setTimeout(() => {
             debug(`Token expired. Logging out.`);
             logout();
           }, ms(authSettings.jwt.expiresIn));


### PR DESCRIPTION
### Summary

Fix the socket authentication immediately logout when setting a very large token expiry time. See #458. This is likely due to 32bit integer overflow in `setTimeout`. It overcome this issue by using the `long-timout` npm package. 
