### PR TITLE
Fix default authentication config keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,7 @@
 # Change Log
 
-## [Unreleased](https://github.com/feathersjs/feathers-authentication/tree/HEAD)
-
-[Full Changelog](https://github.com/feathersjs/feathers-authentication/compare/v1.2.2...HEAD)
+## [v1.2.3](https://github.com/feathersjs/feathers-authentication/tree/v1.2.3) (2017-05-10)
+[Full Changelog](https://github.com/feathersjs/feathers-authentication/compare/v1.2.2...v1.2.3)
 
 **Closed issues:**
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ These other middleware are included and exposed but typically you don't need to 
 
 ### Default Options
 
-The following default options will be mixed in with your global `auth` object from your config file. It will set the mixed options back on to the app so that they are available at any time by calling `app.get('auth')`. They can all be overridden and are depended upon by some of the authentication plugins.
+The following default options will be mixed in with your global `auth` object from your config file. It will set the mixed options back on to the app so that they are available at any time by calling `app.get('authentication')`. They can all be overridden and are depended upon by some of the authentication plugins.
 
 ```js
 {

--- a/docs/migrating.md
+++ b/docs/migrating.md
@@ -50,7 +50,7 @@ For most of you, migrating your app should be fairly straight forward as there a
 const authentication = require('feathers-authentication');
 const FacebookStrategy = require('passport-facebook').Strategy;
 
-let config = app.get('auth');
+let config = app.get('authentication');
 config.facebook.strategy = FacebookStrategy;
 app.configure(authentication(config))
     .use('/users', memory()) // this use to be okay to be anywhere
@@ -83,7 +83,7 @@ const FacebookStrategy = require('passport-facebook').Strategy;
 
 // The services you are setting the `entity` param for need to be registered before authentication
 app.use('/users', memory())
-    .configure(auth(app.get('auth')))
+    .configure(auth(app.get('authentication')))
     .configure(jwt())
     .configure(local())
     .configure(oauth1())

--- a/src/index.js
+++ b/src/index.js
@@ -30,7 +30,7 @@ export default function init (config = {}) {
       options.cookie.secure = false;
     }
 
-    app.set('auth', options);
+    app.set('authentication', options);
 
     debug('Setting up Passport');
     // Set up our framework adapter

--- a/src/index.js
+++ b/src/index.js
@@ -31,6 +31,7 @@ export default function init (config = {}) {
     }
 
     app.set('authentication', options);
+    app.set('auth', options);
 
     debug('Setting up Passport');
     // Set up our framework adapter

--- a/src/service.js
+++ b/src/service.js
@@ -11,7 +11,7 @@ class Service {
   }
 
   create (data = {}, params = {}) {
-    const defaults = this.app.get('auth');
+    const defaults = this.app.get('authentication');
     const payload = merge(data.payload, params.payload);
 
     // create accessToken
@@ -26,7 +26,7 @@ class Service {
   }
 
   remove (id, params) {
-    const defaults = this.app.get('auth');
+    const defaults = this.app.get('authentication');
     const authHeader = params.headers && params.headers[defaults.header.toLowerCase()];
     const authParams = authHeader && authHeader.match(/(\S+)\s+(\S+)/);
     const accessToken = id !== null ? id : (authParams && authParams[2]) || authHeader;

--- a/src/service.js
+++ b/src/service.js
@@ -11,7 +11,7 @@ class Service {
   }
 
   create (data = {}, params = {}) {
-    const defaults = this.app.get('authentication') || app.get('auth');
+    const defaults = this.app.get('authentication') || this.app.get('auth');
     const payload = merge(data.payload, params.payload);
 
     // create accessToken
@@ -26,7 +26,7 @@ class Service {
   }
 
   remove (id, params) {
-    const defaults = this.app.get('authentication') || app.get('auth');
+    const defaults = this.app.get('authentication') || this.app.get('auth');
     const authHeader = params.headers && params.headers[defaults.header.toLowerCase()];
     const authParams = authHeader && authHeader.match(/(\S+)\s+(\S+)/);
     const accessToken = id !== null ? id : (authParams && authParams[2]) || authHeader;

--- a/src/service.js
+++ b/src/service.js
@@ -11,7 +11,7 @@ class Service {
   }
 
   create (data = {}, params = {}) {
-    const defaults = this.app.get('authentication');
+    const defaults = this.app.get('authentication') || app.get('auth');
     const payload = merge(data.payload, params.payload);
 
     // create accessToken
@@ -26,7 +26,7 @@ class Service {
   }
 
   remove (id, params) {
-    const defaults = this.app.get('authentication');
+    const defaults = this.app.get('authentication') || app.get('auth');
     const authHeader = params.headers && params.headers[defaults.header.toLowerCase()];
     const authParams = authHeader && authHeader.match(/(\S+)\s+(\S+)/);
     const accessToken = id !== null ? id : (authParams && authParams[2]) || authHeader;

--- a/src/socket/handler.js
+++ b/src/socket/handler.js
@@ -18,7 +18,7 @@ function handleSocketCallback (promise, callback) {
 }
 
 export default function setupSocketHandler (app, options, { feathersParams, provider, emit, disconnect }) {
-  const authSettings = app.get('auth');
+  const authSettings = app.get('authentication');
   const service = app.service(authSettings.path);
 
   return function (socket) {

--- a/src/socket/handler.js
+++ b/src/socket/handler.js
@@ -18,7 +18,7 @@ function handleSocketCallback (promise, callback) {
 }
 
 export default function setupSocketHandler (app, options, { feathersParams, provider, emit, disconnect }) {
-  const authSettings = app.get('authentication');
+  const authSettings = app.get('authentication') || app.get('auth');
   const service = app.service(authSettings.path);
 
   return function (socket) {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -62,7 +62,7 @@ describe('Feathers Authentication', () => {
     it('sets cookie to be insecure', () => {
       app.set('env', 'development');
       app.configure(authentication(config));
-      expect(app.get('auth').cookie.secure).to.equal(false);
+      expect(app.get('authentication').cookie.secure).to.equal(false);
     });
   });
 
@@ -70,7 +70,7 @@ describe('Feathers Authentication', () => {
     it('sets cookie to be insecure', () => {
       app.set('env', 'test');
       app.configure(authentication(config));
-      expect(app.get('auth').cookie.secure).to.equal(false);
+      expect(app.get('authentication').cookie.secure).to.equal(false);
     });
   });
 
@@ -78,14 +78,14 @@ describe('Feathers Authentication', () => {
     it('sets cookie to be secure', () => {
       app.set('env', 'production');
       app.configure(authentication(config));
-      expect(app.get('auth').cookie.secure).to.equal(true);
+      expect(app.get('authentication').cookie.secure).to.equal(true);
     });
   });
 
   it('sets custom config options', () => {
     config.custom = 'custom';
     app.configure(authentication(config));
-    expect(app.get('auth').custom).to.equal('custom');
+    expect(app.get('authentication').custom).to.equal('custom');
   });
 
   it('sets up feathers passport adapter', () => {

--- a/test/integration/primus.test.js
+++ b/test/integration/primus.test.js
@@ -34,11 +34,11 @@ describe('Primus authentication', function () {
   let accessToken;
 
   before(done => {
-    const options = merge({}, app.get('auth'), { jwt: { expiresIn: '1ms' } });
+    const options = merge({}, app.get('authentication'), { jwt: { expiresIn: '1ms' } });
     app.passport.createJWT({}, options)
       .then(token => {
         expiredToken = token;
-        return app.passport.createJWT({ userId: 0 }, app.get('auth'));
+        return app.passport.createJWT({ userId: 0 }, app.get('authentication'));
       })
       .then(token => {
         accessToken = token;
@@ -93,7 +93,7 @@ describe('Primus authentication', function () {
           socket.send('authenticate', data, (error, response) => {
             expect(error).to.not.be.ok;
             expect(response.accessToken).to.exist;
-            app.passport.verifyJWT(response.accessToken, app.get('auth')).then(payload => {
+            app.passport.verifyJWT(response.accessToken, app.get('authentication')).then(payload => {
               expect(payload).to.exist;
               expect(payload.iss).to.equal('feathers');
               expect(payload.userId).to.equal(0);
@@ -168,7 +168,7 @@ describe('Primus authentication', function () {
           socket.send('authenticate', data, (error, response) => {
             expect(error).to.not.be.ok;
             expect(response.accessToken).to.exist;
-            app.passport.verifyJWT(response.accessToken, app.get('auth')).then(payload => {
+            app.passport.verifyJWT(response.accessToken, app.get('authentication')).then(payload => {
               expect(payload).to.exist;
               expect(payload.iss).to.equal('feathers');
               expect(payload.userId).to.equal(0);
@@ -185,7 +185,7 @@ describe('Primus authentication', function () {
           socket.send('authenticate', data, (error, response) => {
             expect(error).to.not.be.ok;
             expect(response.accessToken).to.exist;
-            app.passport.verifyJWT(response.accessToken, app.get('auth')).then(payload => {
+            app.passport.verifyJWT(response.accessToken, app.get('authentication')).then(payload => {
               expect(payload).to.exist;
               expect(payload.iss).to.equal('feathers');
               expect(payload.userId).to.equal(0);

--- a/test/integration/rest.test.js
+++ b/test/integration/rest.test.js
@@ -18,11 +18,11 @@ describe('REST authentication', function () {
   let accessToken;
 
   before(done => {
-    const options = merge({}, app.get('auth'), { jwt: { expiresIn: '1ms' } });
+    const options = merge({}, app.get('authentication'), { jwt: { expiresIn: '1ms' } });
     app.passport.createJWT({}, options)
       .then(token => {
         expiredToken = token;
-        return app.passport.createJWT({ userId: 0 }, app.get('auth'));
+        return app.passport.createJWT({ userId: 0 }, app.get('authentication'));
       })
       .then(token => {
         accessToken = token;
@@ -52,7 +52,7 @@ describe('REST authentication', function () {
             .send(data)
             .then(response => {
               expect(response.body.accessToken).to.exist;
-              return app.passport.verifyJWT(response.body.accessToken, app.get('auth'));
+              return app.passport.verifyJWT(response.body.accessToken, app.get('authentication'));
             }).then(payload => {
               expect(payload).to.exist;
               expect(payload.iss).to.equal('feathers');
@@ -107,7 +107,7 @@ describe('REST authentication', function () {
             .send(data)
             .then(response => {
               expect(response.body.accessToken).to.exist;
-              return app.passport.verifyJWT(response.body.accessToken, app.get('auth'));
+              return app.passport.verifyJWT(response.body.accessToken, app.get('authentication'));
             }).then(payload => {
               expect(payload).to.exist;
               expect(payload.iss).to.equal('feathers');
@@ -123,7 +123,7 @@ describe('REST authentication', function () {
             .send(data)
             .then(response => {
               expect(response.body.accessToken).to.exist;
-              return app.passport.verifyJWT(response.body.accessToken, app.get('auth'));
+              return app.passport.verifyJWT(response.body.accessToken, app.get('authentication'));
             }).then(payload => {
               expect(payload).to.exist;
               expect(payload.iss).to.equal('feathers');

--- a/test/integration/socketio.test.js
+++ b/test/integration/socketio.test.js
@@ -33,11 +33,11 @@ describe('Socket.io authentication', function () {
   let accessToken;
 
   before(done => {
-    const options = merge({}, app.get('auth'), { jwt: { expiresIn: '1ms' } });
+    const options = merge({}, app.get('authentication'), { jwt: { expiresIn: '1ms' } });
     app.passport.createJWT({}, options)
       .then(token => {
         expiredToken = token;
-        return app.passport.createJWT({ userId: 0 }, app.get('auth'));
+        return app.passport.createJWT({ userId: 0 }, app.get('authentication'));
       })
       .then(token => {
         accessToken = token;
@@ -87,7 +87,7 @@ describe('Socket.io authentication', function () {
           socket.emit('authenticate', data, (error, response) => {
             expect(error).to.not.equal(undefined);
             expect(response.accessToken).to.exist;
-            app.passport.verifyJWT(response.accessToken, app.get('auth')).then(payload => {
+            app.passport.verifyJWT(response.accessToken, app.get('authentication')).then(payload => {
               expect(payload).to.exist;
               expect(payload.iss).to.equal('feathers');
               expect(payload.userId).to.equal(0);
@@ -162,7 +162,7 @@ describe('Socket.io authentication', function () {
           socket.emit('authenticate', data, (error, response) => {
             expect(error).to.not.be.ok;
             expect(response.accessToken).to.exist;
-            app.passport.verifyJWT(response.accessToken, app.get('auth')).then(payload => {
+            app.passport.verifyJWT(response.accessToken, app.get('authentication')).then(payload => {
               expect(payload).to.exist;
               expect(payload.iss).to.equal('feathers');
               expect(payload.userId).to.equal(0);
@@ -179,7 +179,7 @@ describe('Socket.io authentication', function () {
           socket.emit('authenticate', data, (error, response) => {
             expect(error).to.not.be.ok;
             expect(response.accessToken).to.exist;
-            app.passport.verifyJWT(response.accessToken, app.get('auth')).then(payload => {
+            app.passport.verifyJWT(response.accessToken, app.get('authentication')).then(payload => {
               expect(payload).to.exist;
               expect(payload.iss).to.equal('feathers');
               expect(payload.userId).to.equal(0);

--- a/test/service.test.js
+++ b/test/service.test.js
@@ -102,7 +102,7 @@ describe('/authentication service', () => {
       return app.service('authentication').create(data, params).then(result => {
         return app.service('authentication').create(data).then(result => {
           return app.passport
-            .verifyJWT(result.accessToken, app.get('auth'))
+            .verifyJWT(result.accessToken, app.get('authentication'))
             .then(payload => {
               const delta = (payload.exp - payload.iat);
               expect(delta).to.equal(24 * 60 * 60);
@@ -117,7 +117,7 @@ describe('/authentication service', () => {
 
     beforeEach(() => {
       return app.passport
-        .createJWT({ id: 1 }, app.get('auth'))
+        .createJWT({ id: 1 }, app.get('authentication'))
         .then(token => { accessToken = token; });
     });
 


### PR DESCRIPTION
### Summary
The default config key was changed to `authentication` and was not updated here. This fixes that. This isn't a breaking change for anyone using v2 of the generator and/or are passing their auth config explicitly when configuring auth plugins:

```js
const config = app.get('auth');
app.configure(authentication(config));
```

but it will be for people that migrated to the new version of auth and still have a config file with:

```js
"auth": {
   // auth config values
}
```

instead of:

```js
"authentication": {
   // auth config values
}
```

For that reason, this and the associated PRs will need to be major releases:

- https://github.com/feathersjs/feathers-authentication-jwt/pull/21
- https://github.com/feathersjs/feathers-authentication-local/pull/22
- https://github.com/feathersjs/feathers-authentication-oauth1/pull/18
- https://github.com/feathersjs/feathers-authentication-oauth2/pull/24