### PR TITLE
Remove hook.data.payload

### DIFF
--- a/docs/migrating.md
+++ b/docs/migrating.md
@@ -229,7 +229,7 @@ By default the payload for your JWT is simply your entity id (ie. `{ userId }`).
 function customizeJWTPayload() {
   return function(hook) {
     console.log('Customizing JWT Payload');
-    hook.data.payload = {
+    hook.params.payload = {
       // You need to make sure you have the right id.
       // You can put whatever you want to be encoded in
       // the JWT access token.
@@ -251,7 +251,7 @@ app.service('authentication').hooks({
     ]
   }
 });
-``` 
+```
 
 ## JWT Parsing
 

--- a/src/service.js
+++ b/src/service.js
@@ -12,7 +12,7 @@ class Service {
 
   create (data = {}, params = {}) {
     const defaults = this.app.get('auth');
-    const payload = merge(data.payload, params.payload);
+    const payload = params.payload;
 
     // create accessToken
     // TODO (EK): Support refresh tokens


### PR DESCRIPTION
This removes `hook.data.payload` because it’s too easy to open a security hole when implementing custom authentication solutions.  `hook.params.payload` is the only default mechanism to customize the JWT, now.  A hook can be used to restore this functionality, if needed.