### PR TITLE
adding a default jwt uuid. Refs #513

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,8 @@
     "lodash.pick": "^4.4.0",
     "long-timeout": "^0.1.1",
     "ms": "^2.0.0",
-    "passport": "^0.3.2"
+    "passport": "^0.3.2",
+    "uuid": "^3.1.0"
   },
   "devDependencies": {
     "babel-cli": "^6.14.0",
@@ -76,6 +77,7 @@
     "babel-preset-es2015": "^6.14.0",
     "body-parser": "^1.15.2",
     "chai": "^3.5.0",
+    "chai-uuid": "^1.0.6",
     "feathers": "^2.0.2",
     "feathers-authentication-jwt": "^0.3.0",
     "feathers-authentication-local": "^0.4.0",

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,4 +1,6 @@
 import Debug from 'debug';
+import uuidv4 from 'uuid/v4';
+import merge from 'lodash.merge';
 import pick from 'lodash.pick';
 import omit from 'lodash.omit';
 import jwt from 'jsonwebtoken';
@@ -22,7 +24,7 @@ export function createJWT (payload = {}, options = {}) {
     'sub',
     'iss'
   ];
-  const settings = Object.assign({}, options.jwt);
+  const settings = merge({ jwtid: uuidv4() }, options.jwt);
   const { secret } = options;
 
   return new Promise((resolve, reject) => {
@@ -55,7 +57,7 @@ export function verifyJWT (token, options = {}) {
     'subject',
     'clockTolerance'
   ];
-  const settings = Object.assign({}, options.jwt);
+  const settings = merge({}, options.jwt);
   const { secret } = options;
 
   // normalize algorithm to array

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -1,7 +1,10 @@
 import jwt from 'jsonwebtoken';
-import { expect } from 'chai';
+import chai, { expect } from 'chai';
+import chaiUuid from 'chai-uuid';
 import { createJWT, verifyJWT } from '../src/utils';
 import getOptions from '../src/options';
+
+chai.use(chaiUuid);
 
 describe('utils', () => {
   let options;
@@ -54,6 +57,10 @@ describe('utils', () => {
       it('has the correct issuer', () => {
         expect(decoded.iss).to.equal(options.jwt.issuer);
       });
+
+      it('has a uuidv4 jwtid', () => {
+        expect(decoded.jti).to.be.a.uuid('v4');
+      });
     });
 
     describe('when passing custom options', () => {
@@ -66,6 +73,7 @@ describe('utils', () => {
         options.jwt.audience = 'org';
         options.jwt.expiresIn = '1y'; // expires in 1 year
         options.jwt.notBefore = '1h'; // token is valid 1 hour from now
+        options.jwt.jwtid = '1234';
 
         return createJWT(payload, options).then(t => {
           token = t;
@@ -91,6 +99,10 @@ describe('utils', () => {
 
       it('has the correct issuer', () => {
         expect(decoded.iss).to.equal('custom');
+      });
+
+      it('has the correct jwtid', () => {
+        expect(decoded.jti).to.equal('1234');
       });
     });
   });


### PR DESCRIPTION
### Summary

We already supported passing your own `jwtid` by setting `hook.params.jwt.jwtid = myId` before an authentication `create` call or by explicitly calling:

```js
const options = {
  jwt: {
    jwtid: myId
  }
};
app.passport.createJWT(payload, options).then(...
```

This PR makes it so that by default a uuid is assigned to the jwtid value. This sets us up better so that we can whitelist/blacklist tokens.