### PR TITLE
Make feathers-authentication match security documents

### DIFF
--- a/src/options.js
+++ b/src/options.js
@@ -18,7 +18,7 @@ const defaults = {
     audience: 'https://yourdomain.com', // The resource server where the token is processed
     subject: 'anonymous', // Typically the entity id associated with the JWT
     issuer: 'feathers', // The issuing server, application or resource
-    algorithm: 'HS256',
+    algorithm: 'HS512',
     expiresIn: '1d'
   }
 };

--- a/test/options.test.js
+++ b/test/options.test.js
@@ -81,7 +81,7 @@ describe('options', () => {
       });
 
       it('sets the algorithm', () => {
-        expect(options.jwt.algorithm).to.equal('HS256');
+        expect(options.jwt.algorithm).to.equal('HS512');
       });
 
       it('sets the expiresIn', () => {


### PR DESCRIPTION
This pull request is a simple one that makes the code match the documentation.

Feathers.js documentation currently says [HS512 is used for authentication](https://github.com/feathersjs/feathers-docs/blob/master/SECURITY.md), however, the default `options` in `feathers-authentication` appears to use `HS256`. Instead of issuing a pull request to decrease overall security of the authentication module, this pull request makes the defaults of `feathers-authentication` match the algorithm as described in the documentation.

Clearly one or the other is not fully accurate. 😄 This PR changes `feathers-authentication` to the HS512 default, but it may make more sense to change the document if this was intentional.

This is not reported as a security vulnerability because IMO it doesn't change the security posture of this application too much at this stage. Of course, a much better crypto person than I could say I am completely wrong and there are attacks on the HS256 construct that I am unaware of.

### Warning

This hasn't been tested aside from changing the values and watching tests pass.