### PR TITLE
Revert "Make feathers-authentication match security documents"

### DIFF
--- a/src/options.js
+++ b/src/options.js
@@ -18,7 +18,7 @@ const defaults = {
     audience: 'https://yourdomain.com', // The resource server where the token is processed
     subject: 'anonymous', // Typically the entity id associated with the JWT
     issuer: 'feathers', // The issuing server, application or resource
-    algorithm: 'HS512',
+    algorithm: 'HS256',
     expiresIn: '1d'
   }
 };

--- a/test/options.test.js
+++ b/test/options.test.js
@@ -81,7 +81,7 @@ describe('options', () => {
       });
 
       it('sets the algorithm', () => {
-        expect(options.jwt.algorithm).to.equal('HS512');
+        expect(options.jwt.algorithm).to.equal('HS256');
       });
 
       it('sets the expiresIn', () => {


### PR DESCRIPTION
Reverts feathersjs/feathers-authentication#554

This is a breaking change so it needs to go into the v2.0.0 release.