### PR TITLE
Resolves #609 - Permit the developer to provide a custom authentication service implementation

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -49,9 +49,7 @@ function init (config = {}) {
       app.use(express.exposeCookies());
     }
 
-    // TODO (EK): Support passing your own service or force
-    // developer to register it themselves.
-    app.configure(service(options));
+    app.configure(options.authenticationService(options));
     app.passport.initialize();
 
     app.setup = function () {

--- a/lib/options.js
+++ b/lib/options.js
@@ -1,10 +1,12 @@
 const merge = require('lodash.merge');
+const service = require('./service');
 
 const defaults = {
   path: '/authentication',
   header: 'Authorization',
   entity: 'user',
   service: 'users',
+  authenticationService: service,
   passReqToCallback: true,
   session: false,
   cookie: {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -130,6 +130,28 @@ describe('Feathers Authentication', () => {
     expect(app.service('authentication')).to.not.equal(undefined);
   });
 
+  it('registers custom authentication service', (done) => {
+    class Service {
+      create () {
+        return Promise.resolve('success');
+      }
+    }
+    config.authenticationService = function (options) {
+      return function () {
+        this.use(options.path, new Service());
+      };
+    };
+    app.configure(authentication(config));
+    expect(app.service('authentication')).to.not.equal(undefined);
+    // Ensure that it's the custom service that has been registered
+    app.service('authentication').create({})
+      .then((result) => {
+        expect(result).to.equal('success');
+        done();
+      })
+      .catch(done);
+  });
+
   describe('when cookies are enabled', () => {
     it('registers the express exposeCookies middleware', () => {
       config = Object.assign(config, { cookie: { enabled: true } });


### PR DESCRIPTION
Resolves #609 by allowing the developer to specify a custom authentication service implementation as part of the options map passed to the authentication middleware.

I am not sure if there's any documentation I should update to accompany this. Please advise if this is necessary.