### PR TITLE
Restore authentication chaining

### DIFF
--- a/lib/hooks/authenticate.js
+++ b/lib/hooks/authenticate.js
@@ -22,15 +22,13 @@ module.exports = function authenticate (strategies, options = {}) {
 
     hook.data = hook.data || {};
 
-    let { strategy } = hook.data;
-
     // Handle the case where authenticate hook was registered without a passport strategy specified
     if (!strategies) {
       return Promise.reject(new errors.GeneralError(`You must provide an authentication 'strategy'`));
     }
 
     if (!Array.isArray(strategies)) {
-        strategies = [strategies];
+      strategies = [strategies];
     }
 
     // NOTE (EK): Passport expects an express/connect
@@ -44,85 +42,83 @@ module.exports = function authenticate (strategies, options = {}) {
       session: {}
     };
 
-    console.log("STRATEGIES", strategies);
+    // console.log('STRATEGIES', strategies);
 
     return Promise.all(strategies.map((strategy) => {
-        console.log("STRATEGY", strategy);
-        // The client must send a `strategy` name.
-        if (!app.passport._strategy(strategy)) {
-          return Promise.reject(new errors.BadRequest(`Authentication strategy '${strategy}' is not registered.`));
+      // console.log('STRATEGY', strategy);
+      // The client must send a `strategy` name.
+      if (!app.passport._strategy(strategy)) {
+        return Promise.reject(new errors.BadRequest(`Authentication strategy '${strategy}' is not registered.`));
+      }
+
+      const strategyOptions = merge({}, app.passport.options(strategy), options);
+
+      debug(`Attempting to authenticate using ${strategy} strategy with options`, strategyOptions);
+
+      return app.authenticate(strategy, strategyOptions)(request).then((result = {}) => { // collect the results of every member of the auth chain.  !! TRIGGERS ALL (if any) SIDE EFFECTS !!
+        if (result.fail) {
+          // console.log('FAIL');
+          // TODO (EK): Reject with something...
+          // You get back result.challenge and result.status
+          if (strategyOptions.failureRedirect) {
+            // TODO (EK): Bypass the service?
+            // hook.result = true
+            Object.defineProperty(hook.data, '__redirect', { value: { status: 302, url: strategyOptions.failureRedirect } });
+          }
+
+          const { challenge, status = 401 } = result;
+          let message = challenge && challenge.message ? challenge.message : challenge;
+
+          if (strategyOptions.failureMessage) {
+            message = strategyOptions.failureMessage;
+          }
+
+          return Promise.resolve(new errors[status](message, challenge));
         }
 
-        const strategyOptions = merge({}, app.passport.options(strategy), options);
+        // console.log('NOTFAIL', result);
 
-        debug(`Attempting to authenticate using ${strategy} strategy with options`, strategyOptions);
+        if (result.success) {
+          // console.log('SUCCESS');
+          hook.params = Object.assign({ authenticated: true }, hook.params, result.data);
 
-        return app.authenticate(strategy, strategyOptions)(request).then((result = {}) => { // collect the results of every member of the auth chain.  !! TRIGGERS ALL (if any) SIDE EFFECTS !!
+          // Add the user to the original request object so it's available in the socket handler
+          Object.assign(request.params, hook.params);
 
-            if (result.fail) {
-                console.log("FAIL");
-              // TODO (EK): Reject with something...
-              // You get back result.challenge and result.status
-              if (strategyOptions.failureRedirect) {
-                // TODO (EK): Bypass the service?
-                // hook.result = true
-                Object.defineProperty(hook.data, '__redirect', { value: { status: 302, url: strategyOptions.failureRedirect } });
-              }
+          if (strategyOptions.successRedirect) {
+            // TODO (EK): Bypass the service?
+            // hook.result = true
+            Object.defineProperty(hook.data, '__redirect', { value: { status: 302, url: strategyOptions.successRedirect } });
+          }
+        } else if (result.redirect) {
+          // console.log('REDIRECT');
+          // TODO (EK): Bypass the service?
+          // hook.result = true
+          Object.defineProperty(hook.data, '__redirect', { value: { status: result.status, url: result.url } });
+        }
 
-              const { challenge, status = 401 } = result;
-              let message = challenge && challenge.message ? challenge.message : challenge;
-
-              if (strategyOptions.failureMessage) {
-                message = strategyOptions.failureMessage;
-              }
-
-              return Promise.resolve(new errors[status](message, challenge));
-            }
-
-            console.log("NOTFAIL", result);
-
-            if (result.success) {
-              console.log("SUCCESS");
-              hook.params = Object.assign({ authenticated: true }, hook.params, result.data);
-
-              // Add the user to the original request object so it's available in the socket handler
-              Object.assign(request.params, hook.params);
-
-              if (strategyOptions.successRedirect) {
-                // TODO (EK): Bypass the service?
-                // hook.result = true
-                Object.defineProperty(hook.data, '__redirect', { value: { status: 302, url: strategyOptions.successRedirect } });
-              }
-            } else if (result.redirect) {
-              console.log("REDIRECT");
-              // TODO (EK): Bypass the service?
-              // hook.result = true
-              Object.defineProperty(hook.data, '__redirect', { value: { status: result.status, url: result.url } });
-            }
-
-            return Promise.resolve(hook);
-        });
+        return Promise.resolve(hook);
+      });
     }))
-    .then( (results)=>{
+      .then((results) => {
         if (results.length) {
-            var winner = results.find((result)=>{
-                // console.log("RESULT", typeof result);
-                if (result.app) { // Not an error, probably (?) a hook
-                    return true;
-                }
-                return false;
-            })
-
-            if (winner) {
-                console.log("WINNER", winner);
-                return Promise.resolve(winner);
-            } else {
-                return Promise.reject(results[0]); // They were all (probably) errors, so just return the first one like we used to.
+          var winner = results.find((result) => {
+            // console.log("RESULT", typeof result);
+            if (result.app) { // Not an error, probably (?) a hook
+              return true;
             }
-        } else {
-            return Promise.reject(new errors.GeneralError('No authentication strategies were available.'));
-        }
+            return false;
+          });
 
-    })
-    };
+          if (winner) {
+            // console.log('WINNER', winner);
+            return Promise.resolve(winner);
+          } else {
+            return Promise.reject(results[0]); // They were all (probably) errors, so just return the first one like we used to.
+          }
+        } else {
+          return Promise.reject(new errors.GeneralError('No authentication strategies were available.'));
+        }
+      });
+  };
 };

--- a/lib/hooks/authenticate.js
+++ b/lib/hooks/authenticate.js
@@ -20,7 +20,14 @@ module.exports = function authenticate (strategies, options = {}) {
       return Promise.reject(new Error(`The 'authenticate' hook should only be used as a 'before' hook.`));
     }
 
-    hook.data = hook.data || {};
+    if (hook.data) {
+      strategies = [hook.data.strategy];
+    } else {
+      hook.data = {};
+      if (!Array.isArray(strategies)) {
+        strategies = [strategies];
+      }
+    }
 
     // Handle the case where authenticate hook was registered without a passport strategy specified
     if (!strategies) {
@@ -42,10 +49,8 @@ module.exports = function authenticate (strategies, options = {}) {
       session: {}
     };
 
-    // console.log('STRATEGIES', strategies);
 
     return Promise.all(strategies.map((strategy) => {
-      // console.log('STRATEGY', strategy);
       // The client must send a `strategy` name.
       if (!app.passport._strategy(strategy)) {
         return Promise.reject(new errors.BadRequest(`Authentication strategy '${strategy}' is not registered.`));
@@ -57,12 +62,10 @@ module.exports = function authenticate (strategies, options = {}) {
 
       return app.authenticate(strategy, strategyOptions)(request).then((result = {}) => { // collect the results of every member of the auth chain.  !! TRIGGERS ALL (if any) SIDE EFFECTS !!
         if (result.fail) {
-          // console.log('FAIL');
           // TODO (EK): Reject with something...
           // You get back result.challenge and result.status
           if (strategyOptions.failureRedirect) {
             // TODO (EK): Bypass the service?
-            // hook.result = true
             Object.defineProperty(hook.data, '__redirect', { value: { status: 302, url: strategyOptions.failureRedirect } });
           }
 
@@ -76,10 +79,8 @@ module.exports = function authenticate (strategies, options = {}) {
           return Promise.resolve(new errors[status](message, challenge));
         }
 
-        // console.log('NOTFAIL', result);
 
         if (result.success) {
-          // console.log('SUCCESS');
           hook.params = Object.assign({ authenticated: true }, hook.params, result.data);
 
           // Add the user to the original request object so it's available in the socket handler
@@ -87,13 +88,10 @@ module.exports = function authenticate (strategies, options = {}) {
 
           if (strategyOptions.successRedirect) {
             // TODO (EK): Bypass the service?
-            // hook.result = true
             Object.defineProperty(hook.data, '__redirect', { value: { status: 302, url: strategyOptions.successRedirect } });
           }
         } else if (result.redirect) {
-          // console.log('REDIRECT');
           // TODO (EK): Bypass the service?
-          // hook.result = true
           Object.defineProperty(hook.data, '__redirect', { value: { status: result.status, url: result.url } });
         }
 
@@ -103,7 +101,6 @@ module.exports = function authenticate (strategies, options = {}) {
       .then((results) => {
         if (results.length) {
           var winner = results.find((result) => {
-            // console.log("RESULT", typeof result);
             if (result.app) { // Not an error, probably (?) a hook
               return true;
             }
@@ -111,7 +108,6 @@ module.exports = function authenticate (strategies, options = {}) {
           });
 
           if (winner) {
-            // console.log('WINNER', winner);
             return Promise.resolve(winner);
           } else {
             return Promise.reject(results[0]); // They were all (probably) errors, so just return the first one like we used to.

--- a/lib/hooks/authenticate.js
+++ b/lib/hooks/authenticate.js
@@ -23,22 +23,14 @@ module.exports = function authenticate (strategies, options = {}) {
     hook.data = hook.data || {};
 
     let { strategy } = hook.data;
-    if (!strategy) {
-      if (Array.isArray(strategies)) {
-        strategy = strategies[0];
-      } else {
-        strategy = strategies;
-      }
-    }
 
     // Handle the case where authenticate hook was registered without a passport strategy specified
-    if (!strategy) {
+    if (!strategies) {
       return Promise.reject(new errors.GeneralError(`You must provide an authentication 'strategy'`));
     }
 
-    // The client must send a `strategy` name.
-    if (!app.passport._strategy(strategy)) {
-      return Promise.reject(new errors.BadRequest(`Authentication strategy '${strategy}' is not registered.`));
+    if (!Array.isArray(strategies)) {
+        strategies = [strategies];
     }
 
     // NOTE (EK): Passport expects an express/connect
@@ -52,48 +44,85 @@ module.exports = function authenticate (strategies, options = {}) {
       session: {}
     };
 
-    const strategyOptions = merge({}, app.passport.options(strategy), options);
+    console.log("STRATEGIES", strategies);
 
-    debug(`Attempting to authenticate using ${strategy} strategy with options`, strategyOptions);
-
-    return app.authenticate(strategy, strategyOptions)(request).then((result = {}) => {
-      if (result.fail) {
-        // TODO (EK): Reject with something...
-        // You get back result.challenge and result.status
-        if (strategyOptions.failureRedirect) {
-          // TODO (EK): Bypass the service?
-          // hook.result = true
-          Object.defineProperty(hook.data, '__redirect', { value: { status: 302, url: strategyOptions.failureRedirect } });
+    return Promise.all(strategies.map((strategy) => {
+        console.log("STRATEGY", strategy);
+        // The client must send a `strategy` name.
+        if (!app.passport._strategy(strategy)) {
+          return Promise.reject(new errors.BadRequest(`Authentication strategy '${strategy}' is not registered.`));
         }
 
-        const { challenge, status = 401 } = result;
-        let message = challenge && challenge.message ? challenge.message : challenge;
+        const strategyOptions = merge({}, app.passport.options(strategy), options);
 
-        if (strategyOptions.failureMessage) {
-          message = strategyOptions.failureMessage;
+        debug(`Attempting to authenticate using ${strategy} strategy with options`, strategyOptions);
+
+        return app.authenticate(strategy, strategyOptions)(request).then((result = {}) => { // collect the results of every member of the auth chain.  !! TRIGGERS ALL (if any) SIDE EFFECTS !!
+
+            if (result.fail) {
+                console.log("FAIL");
+              // TODO (EK): Reject with something...
+              // You get back result.challenge and result.status
+              if (strategyOptions.failureRedirect) {
+                // TODO (EK): Bypass the service?
+                // hook.result = true
+                Object.defineProperty(hook.data, '__redirect', { value: { status: 302, url: strategyOptions.failureRedirect } });
+              }
+
+              const { challenge, status = 401 } = result;
+              let message = challenge && challenge.message ? challenge.message : challenge;
+
+              if (strategyOptions.failureMessage) {
+                message = strategyOptions.failureMessage;
+              }
+
+              return Promise.resolve(new errors[status](message, challenge));
+            }
+
+            console.log("NOTFAIL", result);
+
+            if (result.success) {
+              console.log("SUCCESS");
+              hook.params = Object.assign({ authenticated: true }, hook.params, result.data);
+
+              // Add the user to the original request object so it's available in the socket handler
+              Object.assign(request.params, hook.params);
+
+              if (strategyOptions.successRedirect) {
+                // TODO (EK): Bypass the service?
+                // hook.result = true
+                Object.defineProperty(hook.data, '__redirect', { value: { status: 302, url: strategyOptions.successRedirect } });
+              }
+            } else if (result.redirect) {
+              console.log("REDIRECT");
+              // TODO (EK): Bypass the service?
+              // hook.result = true
+              Object.defineProperty(hook.data, '__redirect', { value: { status: result.status, url: result.url } });
+            }
+
+            return Promise.resolve(hook);
+        });
+    }))
+    .then( (results)=>{
+        if (results.length) {
+            var winner = results.find((result)=>{
+                // console.log("RESULT", typeof result);
+                if (result.app) { // Not an error, probably (?) a hook
+                    return true;
+                }
+                return false;
+            })
+
+            if (winner) {
+                console.log("WINNER", winner);
+                return Promise.resolve(winner);
+            } else {
+                return Promise.reject(results[0]); // They were all (probably) errors, so just return the first one like we used to.
+            }
+        } else {
+            return Promise.reject(new errors.GeneralError('No authentication strategies were available.'));
         }
 
-        return Promise.reject(new errors[status](message, challenge));
-      }
-
-      if (result.success) {
-        hook.params = Object.assign({ authenticated: true }, hook.params, result.data);
-
-        // Add the user to the original request object so it's available in the socket handler
-        Object.assign(request.params, hook.params);
-
-        if (strategyOptions.successRedirect) {
-          // TODO (EK): Bypass the service?
-          // hook.result = true
-          Object.defineProperty(hook.data, '__redirect', { value: { status: 302, url: strategyOptions.successRedirect } });
-        }
-      } else if (result.redirect) {
-        // TODO (EK): Bypass the service?
-        // hook.result = true
-        Object.defineProperty(hook.data, '__redirect', { value: { status: result.status, url: result.url } });
-      }
-
-      return Promise.resolve(hook);
-    });
-  };
+    })
+    };
 };


### PR DESCRIPTION

### Summary

The authentication chain terminates on first failure. 

```authenticate(['jwt', 'anon'])```  will never reach the anon strategy, as jwt failure ends the chain.

No known open issues are related to this PR. This PR is independent and does not depend on other PRs.

CAVEATS: This PR is not expected to be acceptable, but it's working for me right now.  

It's to show the core team my solution and point out the problem.  

* Tests are failing and no new tests have been added to support this issue.
* Redirection logic is broken.
* I arbitrarily chose the first failure to report (as the old code did) ... I don't know the proper solution for this.
